### PR TITLE
Fix typo in `design.ipynb`

### DIFF
--- a/tutorials/classiq_concepts/design/design/design.ipynb
+++ b/tutorials/classiq_concepts/design/design/design.ipynb
@@ -180,7 +180,7 @@
     "After a quantum variable is declared it needs to be initialized. There are several ways to initialize quantum variables, and in the above example we can see two ways:\n",
     "\n",
     "* `x` is initialized with the `allocate` operation.\n",
-    "* `y` i initialized with the `|=` (`=` in native) numeric assignment.\n",
+    "* `y` is initialized with the `|=` (`=` in native) numeric assignment.\n",
     "\n",
     "<details> \n",
     "<summary> Types of Initializations </summary>\n",


### PR DESCRIPTION
### PR Description

Fix typo in `design.ipynb`

### Some notes

- [x] Please make sure that you placed the files in an appropriate folder
- [x] And that the files have indicative names.

- [x] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [x] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
