### PR TITLE
fixed a grammatical mistake in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The `.ipynb` files are intended to be viewed inside [JupyterLab](https://jupyter
 
 The simplest quantum circuit has 1 qubit, and has a single `X` gate.
 
-Using Classiq's SDK, it would like like so:
+Using Classiq's SDK, it would look like so:
 
 ```python
 from classiq import *


### PR DESCRIPTION
> ### PR Description

> *When i was going through with the Readme. I noticed that there is a small stylistic improvement mistake just below the "Create Quantum Programs with Classiq". The error was "like like" and it should be "look like". As I saw there was no mistake instead of this grammatical error in the Readme, so I just thought to fix it and tried to make the Classiq readme perfect.
I will put a screenshot below the description and some more reasons to fix it





![Screenshot (5)](https://github.com/user-attachments/assets/715c41ad-b877-4b88-af96-334355afbcee)


> ### Some reasons to fix the error.
> * Little confusing for some users
> * Distracting the flow of understanding
> * The only small stylistic improvement


### Some notes

- [x] Please make sure that you placed the files in an appropriate folder
- [x] And that the files have indicative names.

- [x] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [x] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
