### PR TITLE
Fix Qmods that use reserved word "phase" as variable name

### DIFF
--- a/functions/open_library_definitions/amplitude_estimation.qmod
+++ b/functions/open_library_definitions/amplitude_estimation.qmod
@@ -1,6 +1,6 @@
-qfunc amplitude_estimation(oracle: qfunc (qbit[]), space_transform: qfunc (qbit[]), phase: qnum, packed_vars: qbit[]) {
+qfunc amplitude_estimation(oracle: qfunc (qbit[]), space_transform: qfunc (qbit[]), phase_var: qnum, packed_vars: qbit[]) {
   space_transform(packed_vars);
   qpe(lambda() {
     grover_operator(oracle, space_transform, packed_vars);
-  }, phase);
+  }, phase_var);
 }

--- a/functions/open_library_definitions/qpe.qmod
+++ b/functions/open_library_definitions/qpe.qmod
@@ -1,7 +1,7 @@
-qfunc qpe(unitary: qfunc (), phase: qnum) {
+qfunc qpe(unitary: qfunc (), phase_var: qnum) {
   qpe_flexible(lambda(k) {
     power (k) {
       unitary();
     }
-  }, phase);
+  }, phase_var);
 }

--- a/functions/open_library_definitions/qpe_flexible.qmod
+++ b/functions/open_library_definitions/qpe_flexible.qmod
@@ -1,6 +1,6 @@
-qfunc qpe_flexible(unitary_with_power: qfunc (int), phase: qnum) {
+qfunc qpe_flexible(unitary_with_power: qfunc (int), phase_var: qnum) {
   phase_array: qbit[];
-  phase -> phase_array;
+  phase_var -> phase_array;
   apply_to_all(H, phase_array);
   repeat (index: phase_array.len) {
     control (phase_array[index]) {
@@ -10,5 +10,5 @@ qfunc qpe_flexible(unitary_with_power: qfunc (int), phase: qnum) {
   invert {
     qft(phase_array);
   }
-  phase_array -> phase;
+  phase_array -> phase_var;
 }


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [x] Please make sure that you placed the files in an appropriate folder
- [x] And that the files have indicative names.

- [x] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [x] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
