### PR TITLE
Fixing bug of running all notebooks when it is not needed

### DIFF
--- a/.github/workflows/test-CI.yml
+++ b/.github/workflows/test-CI.yml
@@ -147,7 +147,7 @@ jobs:
         run: python -m pytest --log-cli-level=INFO tests
         env:
           JUPYTER_PLATFORM_DIRS: "1"
-          SHOULD_TEST_ALL_FILES: "true" # Assuming this is always set to 'true' in the workflow
+          SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
           LIST_OF_IPYNB_CHANGED: "**/*.ipynb" # Set to match all notebook files
           CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
           CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that you placed the files in an appropriate folder
- [ ] And that the files have indicative names.

- [ ] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [ ] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
