### PR TITLE
Change deployment trigger to `pull_request_target`

### DIFF
--- a/.github/workflows/automatic-deployment.yml
+++ b/.github/workflows/automatic-deployment.yml
@@ -1,21 +1,23 @@
 name: "Automatic Deployment"
 
 on:
-  push:
+  pull_request:
     branches:
       - main
       - dev
+    types:
+      - closed
 
 jobs:
   deploy-prod:
-    if: github.ref_name == 'main'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     uses: ./.github/workflows/deployment-qmod.yml
     with:
       deploy-mode: production
     secrets: inherit
 
   deploy-dev:
-    if: github.ref_name == 'dev'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'dev'
     uses: ./.github/workflows/deployment-qmod.yml
     with:
       deploy-mode: staging

--- a/.github/workflows/automatic-deployment.yml
+++ b/.github/workflows/automatic-deployment.yml
@@ -1,7 +1,7 @@
 name: "Automatic Deployment"
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - dev


### PR DESCRIPTION
### PR Description

Revert #619 and simply change the trigger to `pull_request_target`. Based on [GH docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows), both `pull_reqest.merged` and `pull_request.base.ref` should still be available
