### PR TITLE
split test ci workflows 2

### DIFF
--- a/.github/workflows/Test-CI-dev-daily.yml
+++ b/.github/workflows/Test-CI-dev-daily.yml
@@ -1,0 +1,73 @@
+name: "Test CI Dev (daily)"
+
+on:
+  # Schedule the workflow to run every day at 19:00 UTC
+  schedule:
+    - cron: "00 19 * * *"
+
+  # Add a manual trigger option for running the workflow
+  workflow_dispatch:
+
+jobs:
+  nightly-test:
+    permissions:
+      id-token: write
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Debug
+        run: git status
+
+      - name: Install dependencies
+        run: |
+          set -e
+          python -m pip install --extra-index-url https://pypi.org/simple --pre -U -r requirements.txt
+          python -m pip install --extra-index-url https://pypi.org/simple -U -r requirements_tests.txt
+
+      # Set environment variables for the dev environment
+      - name: Set environment for nightly dev run
+        run: |
+          set -ex
+          echo "Running on dev environment."
+          echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
+          echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
+          echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
+          echo "IS_DEV=true" >> $GITHUB_ENV
+        shell: bash
+
+      # Configure AWS credentials
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+
+      # Set authentication with M2M token
+      - name: Set authentication
+        run: .github/scripts/get_m2m_token.sh
+        shell: bash
+        env:
+          IS_DEV: "${{ env.IS_DEV }}"
+          M2M_SECRET_ARN: "${{ env.M2M_SECRET_ARN }}"
+
+      # Run Notebook Tests
+      - name: Run Notebooks
+        run: python -m pytest --log-cli-level=INFO tests
+        env:
+          JUPYTER_PLATFORM_DIRS: "1"
+          SHOULD_TEST_ALL_FILES: "true" # Assuming this is always set to 'true' in the workflow
+          LIST_OF_IPYNB_CHANGED: "**/*.ipynb" # Set to match all notebook files
+          CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
+          CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"
+        shell: bash

--- a/.github/workflows/Test-CI-dev-daily.yml
+++ b/.github/workflows/Test-CI-dev-daily.yml
@@ -8,6 +8,10 @@ on:
   # Add a manual trigger option for running the workflow
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   nightly-test:
     permissions:
@@ -31,19 +35,9 @@ jobs:
       - name: Install dependencies
         run: |
           set -e
+          python -m pip install -U pip
           python -m pip install --extra-index-url https://pypi.org/simple --pre -U -r requirements.txt
           python -m pip install --extra-index-url https://pypi.org/simple -U -r requirements_tests.txt
-
-      # Set environment variables for the dev environment
-      - name: Set environment for nightly dev run
-        run: |
-          set -ex
-          echo "Running on dev environment."
-          echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-          echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
-          echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
-          echo "IS_DEV=true" >> $GITHUB_ENV
-        shell: bash
 
       # Configure AWS credentials
       - name: Configure AWS Credentials
@@ -56,18 +50,18 @@ jobs:
       # Set authentication with M2M token
       - name: Set authentication
         run: .github/scripts/get_m2m_token.sh
-        shell: bash
         env:
-          IS_DEV: "${{ env.IS_DEV }}"
-          M2M_SECRET_ARN: "${{ env.M2M_SECRET_ARN }}"
+          IS_DEV: "true"
+          M2M_SECRET_ARN: "${{ secrets.NIGHTLY_M2M_SECRET_ARN }}"
 
       # Run Notebook Tests
       - name: Run Notebooks
         run: python -m pytest --log-cli-level=INFO tests
         env:
+          # to disable a warning in Jupyter notebooks
           JUPYTER_PLATFORM_DIRS: "1"
-          SHOULD_TEST_ALL_FILES: "true" # Assuming this is always set to 'true' in the workflow
-          LIST_OF_IPYNB_CHANGED: "**/*.ipynb" # Set to match all notebook files
-          CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
-          CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"
-        shell: bash
+          # Passing which notebooks changed
+          SHOULD_TEST_ALL_FILES: "true"
+          # Passing environment information
+          CLASSIQ_IDE: "https://nightly.platform.classiq.io"
+          CLASSIQ_HOST: "https://staging.api.classiq.io"

--- a/.github/workflows/Test-CI-dev.yml
+++ b/.github/workflows/Test-CI-dev.yml
@@ -1,15 +1,28 @@
-name: "Test CI Dev"
+name: "Test Library CI (dev)"
+
+# This workflow always run in the context of Classiq/classiq-library (base repo) but might use a branch from a fork to test its contribution
+# PRs from users (should be from a fork) need to targePrint repository namet `main` branch which runs against `prod` environment
+# PRs from maintainers team (might be from the base repo) need to target `dev` branch and runs against `dev` environment (nightly)
 
 on:
-  # Schedule the workflow to run every day at 19:00 UTC
-  schedule:
-    - cron: "00 19 * * *"
+  push: # Trigger the workflow on push to the specific branch
+    branches:
+      - dev
+      - main
+  pull_request_target: # Trigger the workflow on pull requests targeting the specific branch
+    # Note: `pull_request_target` ensures that the tests run in the context of the `main` branch, not in the user's fork.
+    branches:
+      - dev
+      - main
 
-  # Add a manual trigger option for running the workflow
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  nightly-test:
+  test:
     permissions:
       id-token: write
       contents: read
@@ -17,33 +30,119 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      #
+      # Setup Repository
+      #
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Checkout the target branch
+        id: checkout
+        run: |
+          set -ex
+
+          # Debugging: initial git status
+          echo "==== Git status before checkout ===="
+          git status
+
+          # Handle different GitHub Actions events
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "Handling pull_request_target event"
+            echo "SHOULD_TEST_ALL_FILES=false" >> $GITHUB_ENV
+            target_branch="${{ github.event.pull_request.base.ref }}"
+
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "PR from a fork detected. Checking out the fork's branch."
+              git remote add fork https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
+              git fetch fork ${{ github.event.pull_request.head.ref }}
+              git checkout -B ci-testing-branch FETCH_HEAD # Tested code is comming from this branch (contributer's)
+            else
+              echo "PR from the same repository detected. Checking out the branch."
+              git fetch origin ${{ github.event.pull_request.head.ref }}
+              git checkout ${{ github.event.pull_request.head.ref }}
+            fi
+
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Handling workflow_dispatch event: No checkout needed"
+            target_branch="${{ github.ref_name }}"
+            echo "SHOULD_TEST_ALL_FILES=true" >> $GITHUB_ENV
+            echo "list_of_ipynb_changed=**/*.ipynb" >> $GITHUB_ENV
+
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "Handling push event: No checkout needed"
+            target_branch="${{ github.ref_name }}"
+
+          else
+            echo "Unsupported event type: ${github.event_name}. Exiting."
+            exit 1
+          fi
+
+          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
+
+          # Debugging: final git status
+          echo "==== Git status after checkout ===="
+          git status
+
+      #
+      # Setup Python
+      #
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Debug
-        run: git status
+      - name: Get latest classiq version
+        id: classiq-version
+        run: |
+          echo "LATEST_CLASSIQ_VERSION=$(pip index versions classiq 2>/dev/null | grep classiq | cut -d '(' -f2 | cut -d ')' -f1)" >> $GITHUB_OUTPUT
+
+      # The caching we do follows from
+      #   https://stackoverflow.com/questions/59127258/how-can-i-use-pip-cache-in-github-actions
+      - uses: actions/cache@v2
+        id: cache-pip
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}-classiq-${{steps.classiq-version.outputs.LATEST_CLASSIQ_VERSION}}
+          restore-keys: |
+            ${{ runner.os }}-venv-
 
       - name: Install dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |
           set -e
+          python -m pip install -U pip
+          # The `--pre` allows the installation of pre-release versions of packages (needed for Dev)
           python -m pip install --extra-index-url https://pypi.org/simple --pre -U -r requirements.txt
           python -m pip install --extra-index-url https://pypi.org/simple -U -r requirements_tests.txt
 
-      # Set environment variables for the dev environment
-      - name: Set environment for nightly dev run
+      #
+      # Setup Environment
+      #
+      # A bunch of if-else.
+      # Decide environment based on the target branch (for both push and PR events)
+      - name: Set environment based on target branch
         run: |
+          target_branch=${{ steps.checkout.outputs.target_branch }}
           set -ex
-          echo "Running on dev environment."
-          echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-          echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
-          echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
-          echo "IS_DEV=true" >> $GITHUB_ENV
-        shell: bash
+          if [[ "$target_branch" == "main" ]]; then
+            echo "Running on prod environment."
+
+            echo "M2M_SECRET_ARN=${{ secrets.PROD_M2M_SECRET_ARN }}" >> $GITHUB_ENV
+
+            echo "CLASSIQ_IDE=https://platform.classiq.io" >> $GITHUB_ENV
+            echo "CLASSIQ_HOST=https://api.classiq.io" >> $GITHUB_ENV
+            echo "IS_DEV=false" >> $GITHUB_ENV
+          else
+            echo "Running on dev environment."
+
+            echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
+
+            echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
+            echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
+            echo "IS_DEV=true" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # Configure AWS credentials
       - name: Configure AWS Credentials
@@ -56,18 +155,29 @@ jobs:
       # Set authentication with M2M token
       - name: Set authentication
         run: .github/scripts/get_m2m_token.sh
-        shell: bash
         env:
           IS_DEV: "${{ env.IS_DEV }}"
           M2M_SECRET_ARN: "${{ env.M2M_SECRET_ARN }}"
+
+      #
+      # Propagate CI information to python tests
+      #
+      - name: Get changed notebook files
+        id: changed-files-ipynb
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **/*.ipynb
 
       # Run Notebook Tests
       - name: Run Notebooks
         run: python -m pytest --log-cli-level=INFO tests
         env:
+          # to disable a warning in Jupyter notebooks
           JUPYTER_PLATFORM_DIRS: "1"
-          SHOULD_TEST_ALL_FILES: "true" # Assuming this is always set to 'true' in the workflow
-          LIST_OF_IPYNB_CHANGED: "**/*.ipynb" # Set to match all notebook files
+          # Passing which notebooks changed
+          SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
+          LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
+          # Passing environment information
           CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
           CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"
-        shell: bash

--- a/.github/workflows/Test-CI-dev.yml
+++ b/.github/workflows/Test-CI-dev.yml
@@ -44,7 +44,6 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             echo "Handling pull_request_target event"
             echo "SHOULD_TEST_ALL_FILES=false" >> $GITHUB_ENV
-            target_branch="${{ github.event.pull_request.base.ref }}"
 
             if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
               echo "PR from a fork detected. Checking out the fork's branch."
@@ -59,20 +58,16 @@ jobs:
 
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Handling workflow_dispatch event: No checkout needed"
-            target_branch="${{ github.ref_name }}"
             echo "SHOULD_TEST_ALL_FILES=true" >> $GITHUB_ENV
             echo "list_of_ipynb_changed=**/*.ipynb" >> $GITHUB_ENV
 
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "Handling push event: No checkout needed"
-            target_branch="${{ github.ref_name }}"
 
           else
             echo "Unsupported event type: ${github.event_name}. Exiting."
             exit 1
           fi
-
-          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
 
           # Debugging: final git status
           echo "==== Git status after checkout ===="

--- a/.github/workflows/Test-CI-dev.yml
+++ b/.github/workflows/Test-CI-dev.yml
@@ -86,21 +86,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Get latest classiq version for cache key
-        id: classiq-version
-        run: |
-          echo "LATEST_CLASSIQ_VERSION=$(pip index versions classiq 2>/dev/null | grep classiq | cut -d '(' -f2 | cut -d ')' -f1)" >> $GITHUB_OUTPUT
-
-      # The caching we do follows from
-      #   https://stackoverflow.com/questions/59127258/how-can-i-use-pip-cache-in-github-actions
-      - uses: actions/cache@v2
-        id: cache-pip
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}-classiq-${{steps.classiq-version.outputs.LATEST_CLASSIQ_VERSION}}
-          restore-keys: |
-            ${{ runner.os }}-venv-
-
       - name: Install dependencies
         if: steps.cache-pip.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/Test-CI-dev.yml
+++ b/.github/workflows/Test-CI-dev.yml
@@ -1,19 +1,14 @@
 name: "Test Library CI (dev)"
 
-# This workflow always run in the context of Classiq/classiq-library (base repo) but might use a branch from a fork to test its contribution
-# PRs from users (should be from a fork) need to targePrint repository namet `main` branch which runs against `prod` environment
-# PRs from maintainers team (might be from the base repo) need to target `dev` branch and runs against `dev` environment (nightly)
+# please note the comments in `test-CI-main.yml`
 
 on:
-  push: # Trigger the workflow on push to the specific branch
+  push:
     branches:
       - dev
-      - main
-  pull_request_target: # Trigger the workflow on pull requests targeting the specific branch
-    # Note: `pull_request_target` ensures that the tests run in the context of the `main` branch, not in the user's fork.
+  pull_request_target:
     branches:
       - dev
-      - main
 
   workflow_dispatch:
 
@@ -91,7 +86,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Get latest classiq version
+      - name: Get latest classiq version for cache key
         id: classiq-version
         run: |
           echo "LATEST_CLASSIQ_VERSION=$(pip index versions classiq 2>/dev/null | grep classiq | cut -d '(' -f2 | cut -d ')' -f1)" >> $GITHUB_OUTPUT
@@ -118,32 +113,6 @@ jobs:
       #
       # Setup Environment
       #
-      # A bunch of if-else.
-      # Decide environment based on the target branch (for both push and PR events)
-      - name: Set environment based on target branch
-        run: |
-          target_branch=${{ steps.checkout.outputs.target_branch }}
-          set -ex
-          if [[ "$target_branch" == "main" ]]; then
-            echo "Running on prod environment."
-
-            echo "M2M_SECRET_ARN=${{ secrets.PROD_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-
-            echo "CLASSIQ_IDE=https://platform.classiq.io" >> $GITHUB_ENV
-            echo "CLASSIQ_HOST=https://api.classiq.io" >> $GITHUB_ENV
-            echo "IS_DEV=false" >> $GITHUB_ENV
-          else
-            echo "Running on dev environment."
-
-            echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-
-            echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
-            echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
-            echo "IS_DEV=true" >> $GITHUB_ENV
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       # Configure AWS credentials
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
@@ -156,8 +125,8 @@ jobs:
       - name: Set authentication
         run: .github/scripts/get_m2m_token.sh
         env:
-          IS_DEV: "${{ env.IS_DEV }}"
-          M2M_SECRET_ARN: "${{ env.M2M_SECRET_ARN }}"
+          IS_DEV: "true"
+          M2M_SECRET_ARN: "${{ secrets.NIGHTLY_M2M_SECRET_ARN }}"
 
       #
       # Propagate CI information to python tests
@@ -179,5 +148,5 @@ jobs:
           SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
           LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
           # Passing environment information
-          CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
-          CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"
+          CLASSIQ_IDE: "https://nightly.platform.classiq.io"
+          CLASSIQ_HOST: "https://staging.api.classiq.io"

--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -46,7 +46,6 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             echo "Handling pull_request_target event"
             echo "SHOULD_TEST_ALL_FILES=false" >> $GITHUB_ENV
-            target_branch="${{ github.event.pull_request.base.ref }}"
 
             if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
               echo "PR from a fork detected. Checking out the fork's branch."
@@ -61,20 +60,16 @@ jobs:
 
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Handling workflow_dispatch event: No checkout needed"
-            target_branch="${{ github.ref_name }}"
             echo "SHOULD_TEST_ALL_FILES=true" >> $GITHUB_ENV
             echo "list_of_ipynb_changed=**/*.ipynb" >> $GITHUB_ENV
 
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "Handling push event: No checkout needed"
-            target_branch="${{ github.ref_name }}"
 
           else
             echo "Unsupported event type: ${github.event_name}. Exiting."
             exit 1
           fi
-
-          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
 
           # Debugging: final git status
           echo "==== Git status after checkout ===="

--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -2,17 +2,14 @@ name: "Test Library CI (main)"
 
 # This workflow always run in the context of Classiq/classiq-library (base repo) but might use a branch from a fork to test its contribution
 # PRs from users (should be from a fork) need to targePrint repository namet `main` branch which runs against `prod` environment
-# PRs from maintainers team (might be from the base repo) need to target `dev` branch and runs against `dev` environment (nightly)
 
 on:
   push: # Trigger the workflow on push to the specific branch
     branches:
-      - dev
       - main
   pull_request_target: # Trigger the workflow on pull requests targeting the specific branch
     # Note: `pull_request_target` ensures that the tests run in the context of the `main` branch, not in the user's fork.
     branches:
-      - dev
       - main
 
   workflow_dispatch:
@@ -91,7 +88,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Get latest classiq version
+      - name: Get latest classiq version for cache key
         id: classiq-version
         run: |
           echo "LATEST_CLASSIQ_VERSION=$(pip index versions classiq 2>/dev/null | grep classiq | cut -d '(' -f2 | cut -d ')' -f1)" >> $GITHUB_OUTPUT
@@ -111,39 +108,12 @@ jobs:
         run: |
           set -e
           python -m pip install -U pip
-          # The `--pre` allows the installation of pre-release versions of packages (needed for Dev)
-          python -m pip install --extra-index-url https://pypi.org/simple --pre -U -r requirements.txt
-          python -m pip install --extra-index-url https://pypi.org/simple -U -r requirements_tests.txt
+          python -m pip install -U -r requirements.txt
+          python -m pip install -U -r requirements_tests.txt
 
       #
       # Setup Environment
       #
-      # A bunch of if-else.
-      # Decide environment based on the target branch (for both push and PR events)
-      - name: Set environment based on target branch
-        run: |
-          target_branch=${{ steps.checkout.outputs.target_branch }}
-          set -ex
-          if [[ "$target_branch" == "main" ]]; then
-            echo "Running on prod environment."
-
-            echo "M2M_SECRET_ARN=${{ secrets.PROD_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-
-            echo "CLASSIQ_IDE=https://platform.classiq.io" >> $GITHUB_ENV
-            echo "CLASSIQ_HOST=https://api.classiq.io" >> $GITHUB_ENV
-            echo "IS_DEV=false" >> $GITHUB_ENV
-          else
-            echo "Running on dev environment."
-
-            echo "M2M_SECRET_ARN=${{ secrets.NIGHTLY_M2M_SECRET_ARN }}" >> $GITHUB_ENV
-
-            echo "CLASSIQ_IDE=https://nightly.platform.classiq.io" >> $GITHUB_ENV
-            echo "CLASSIQ_HOST=https://staging.api.classiq.io" >> $GITHUB_ENV
-            echo "IS_DEV=true" >> $GITHUB_ENV
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
       # Configure AWS credentials
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
@@ -156,8 +126,8 @@ jobs:
       - name: Set authentication
         run: .github/scripts/get_m2m_token.sh
         env:
-          IS_DEV: "${{ env.IS_DEV }}"
-          M2M_SECRET_ARN: "${{ env.M2M_SECRET_ARN }}"
+          IS_DEV: "false"
+          M2M_SECRET_ARN: "${{ secrets.PROD_M2M_SECRET_ARN }}"
 
       #
       # Propagate CI information to python tests
@@ -179,5 +149,5 @@ jobs:
           SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
           LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
           # Passing environment information
-          CLASSIQ_IDE: "${{ env.CLASSIQ_IDE }}"
-          CLASSIQ_HOST: "${{ env.CLASSIQ_HOST }}"
+          CLASSIQ_IDE: "https://platform.classiq.io"
+          CLASSIQ_HOST: "https://api.classiq.io"

--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -1,4 +1,4 @@
-name: Test Library CI
+name: "Test Library CI (main)"
 
 # This workflow always run in the context of Classiq/classiq-library (base repo) but might use a branch from a fork to test its contribution
 # PRs from users (should be from a fork) need to targePrint repository namet `main` branch which runs against `prod` environment


### PR DESCRIPTION
- Initial split of test-CI into main,dev,dev-nightly
- Update Test-CI-main
- Update test-CI-dev
- remove caching from dev test, since I'm not sure about the version name convention for dev versions
- remove unneeded env-vars from the inline script in the CI
- Update test-CI-dev-daily
