### PR TITLE
fixed qmod native probability issue

### DIFF
--- a/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.ipynb
+++ b/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.ipynb
@@ -689,13 +689,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Opening: https://platform.classiq.io/circuit/2rgCnjlPtdxMT2kt8QKmXg5zzZu?version=0.65.4\n"
+      "Opening: https://platform.classiq.io/circuit/2rwe34neCtLDeNlc1hOH6HYVXdn?version=0.66.0\n"
      ]
     }
    ],
    "source": [
     "qprog = synthesize(qmod)\n",
-    "write_qmod(qmod, \"solving_qlsp_with_aqc\")\n",
+    "write_qmod(qmod, \"solving_qlsp_with_aqc\", decimal_precision=5)\n",
     "show(qprog)\n",
     "\n",
     "result_state_vector = execute(qprog).result_value().state_vector"
@@ -929,7 +929,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Opening: https://platform.classiq.io/circuit/2rgD1Vo2e7kdIKRiMBL5bebXkW8?version=0.65.4\n"
+      "Opening: https://platform.classiq.io/circuit/2rweHDjGqIVTawYYsk3Uwic8S9J?version=0.66.0\n"
      ]
     }
    ],
@@ -1055,7 +1055,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Opening: https://platform.classiq.io/circuit/2rgDNT9ZVVOaHuRAhIRhnZ9agA8?version=0.65.4\n"
+      "Opening: https://platform.classiq.io/circuit/2rwei3h5uCQJMppqbZQUFzX2v9y?version=0.66.0\n"
      ]
     }
    ],

--- a/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.qmod
+++ b/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.qmod
@@ -6,69 +6,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.14, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -76,27 +76,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -104,7 +104,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0, 1, 10, qba);
   suzuki_trotter([
@@ -114,69 +114,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1372, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -184,27 +184,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -212,7 +212,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0028, 1, 10, qba);
   suzuki_trotter([
@@ -222,69 +222,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1344, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -292,27 +292,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -320,7 +320,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0056, 1, 10, qba);
   suzuki_trotter([
@@ -330,69 +330,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1316, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -400,27 +400,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -428,7 +428,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0084, 1, 10, qba);
   suzuki_trotter([
@@ -438,69 +438,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1288, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -508,27 +508,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -536,7 +536,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0112, 1, 10, qba);
   suzuki_trotter([
@@ -546,69 +546,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.126, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -616,27 +616,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -644,7 +644,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.014, 1, 10, qba);
   suzuki_trotter([
@@ -654,69 +654,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1232, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -724,27 +724,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -752,7 +752,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0168, 1, 10, qba);
   suzuki_trotter([
@@ -762,69 +762,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1204, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -832,27 +832,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -860,7 +860,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0196, 1, 10, qba);
   suzuki_trotter([
@@ -870,69 +870,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1176, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -940,27 +940,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -968,7 +968,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0224, 1, 10, qba);
   suzuki_trotter([
@@ -978,69 +978,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1148, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1048,27 +1048,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1076,7 +1076,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0252, 1, 10, qba);
   suzuki_trotter([
@@ -1086,69 +1086,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.112, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1156,27 +1156,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1184,7 +1184,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.028, 1, 10, qba);
   suzuki_trotter([
@@ -1194,69 +1194,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1092, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1264,27 +1264,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1292,7 +1292,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0308, 1, 10, qba);
   suzuki_trotter([
@@ -1302,69 +1302,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1064, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1372,27 +1372,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1400,7 +1400,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0336, 1, 10, qba);
   suzuki_trotter([
@@ -1410,69 +1410,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1036, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1480,27 +1480,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1508,7 +1508,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0364, 1, 10, qba);
   suzuki_trotter([
@@ -1518,69 +1518,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.1008, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1588,27 +1588,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1616,7 +1616,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0392, 1, 10, qba);
   suzuki_trotter([
@@ -1626,69 +1626,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.098, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1696,27 +1696,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1724,7 +1724,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.042, 1, 10, qba);
   suzuki_trotter([
@@ -1734,69 +1734,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0952, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1804,27 +1804,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1832,7 +1832,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0448, 1, 10, qba);
   suzuki_trotter([
@@ -1842,69 +1842,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0924, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -1912,27 +1912,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -1940,7 +1940,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0476, 1, 10, qba);
   suzuki_trotter([
@@ -1950,69 +1950,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0896, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2020,27 +2020,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2048,7 +2048,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0504, 1, 10, qba);
   suzuki_trotter([
@@ -2058,69 +2058,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0868, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2128,27 +2128,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2156,7 +2156,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0532, 1, 10, qba);
   suzuki_trotter([
@@ -2166,69 +2166,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.084, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2236,27 +2236,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2264,7 +2264,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.056, 1, 10, qba);
   suzuki_trotter([
@@ -2274,69 +2274,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0812, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2344,27 +2344,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2372,7 +2372,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0588, 1, 10, qba);
   suzuki_trotter([
@@ -2382,69 +2382,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0784, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2452,27 +2452,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2480,7 +2480,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0616, 1, 10, qba);
   suzuki_trotter([
@@ -2490,69 +2490,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0756, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2560,27 +2560,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2588,7 +2588,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0644, 1, 10, qba);
   suzuki_trotter([
@@ -2598,69 +2598,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0728, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2668,27 +2668,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2696,7 +2696,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0672, 1, 10, qba);
   suzuki_trotter([
@@ -2706,69 +2706,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.07, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2776,27 +2776,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2804,7 +2804,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.07, 1, 10, qba);
   suzuki_trotter([
@@ -2814,69 +2814,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0672, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2884,27 +2884,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -2912,7 +2912,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0728, 1, 10, qba);
   suzuki_trotter([
@@ -2922,69 +2922,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0644, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -2992,27 +2992,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3020,7 +3020,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0756, 1, 10, qba);
   suzuki_trotter([
@@ -3030,69 +3030,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0616, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3100,27 +3100,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3128,7 +3128,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0784, 1, 10, qba);
   suzuki_trotter([
@@ -3138,69 +3138,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0588, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3208,27 +3208,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3236,7 +3236,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0812, 1, 10, qba);
   suzuki_trotter([
@@ -3246,69 +3246,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.056, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3316,27 +3316,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3344,7 +3344,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.084, 1, 10, qba);
   suzuki_trotter([
@@ -3354,69 +3354,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0532, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3424,27 +3424,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3452,7 +3452,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0868, 1, 10, qba);
   suzuki_trotter([
@@ -3462,69 +3462,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0504, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3532,27 +3532,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3560,7 +3560,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0896, 1, 10, qba);
   suzuki_trotter([
@@ -3570,69 +3570,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0476, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3640,27 +3640,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3668,7 +3668,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0924, 1, 10, qba);
   suzuki_trotter([
@@ -3678,69 +3678,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0448, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3748,27 +3748,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3776,7 +3776,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.0952, 1, 10, qba);
   suzuki_trotter([
@@ -3786,69 +3786,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.042, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3856,27 +3856,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3884,7 +3884,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.098, 1, 10, qba);
   suzuki_trotter([
@@ -3894,69 +3894,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0392, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -3964,27 +3964,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -3992,7 +3992,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1008, 1, 10, qba);
   suzuki_trotter([
@@ -4002,69 +4002,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0364, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4072,27 +4072,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4100,7 +4100,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1036, 1, 10, qba);
   suzuki_trotter([
@@ -4110,69 +4110,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0336, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4180,27 +4180,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4208,7 +4208,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1064, 1, 10, qba);
   suzuki_trotter([
@@ -4218,69 +4218,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0308, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4288,27 +4288,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4316,7 +4316,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1092, 1, 10, qba);
   suzuki_trotter([
@@ -4326,69 +4326,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.028, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4396,27 +4396,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4424,7 +4424,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.112, 1, 10, qba);
   suzuki_trotter([
@@ -4434,69 +4434,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0252, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4504,27 +4504,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4532,7 +4532,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1148, 1, 10, qba);
   suzuki_trotter([
@@ -4542,69 +4542,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0224, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4612,27 +4612,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4640,7 +4640,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1176, 1, 10, qba);
   suzuki_trotter([
@@ -4650,69 +4650,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0196, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4720,27 +4720,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4748,7 +4748,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1204, 1, 10, qba);
   suzuki_trotter([
@@ -4758,69 +4758,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0168, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4828,27 +4828,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4856,7 +4856,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1232, 1, 10, qba);
   suzuki_trotter([
@@ -4866,69 +4866,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.014, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -4936,27 +4936,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -4964,7 +4964,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.126, 1, 10, qba);
   suzuki_trotter([
@@ -4974,69 +4974,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0112, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -5044,27 +5044,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -5072,7 +5072,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1288, 1, 10, qba);
   suzuki_trotter([
@@ -5082,69 +5082,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0084, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -5152,27 +5152,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -5180,7 +5180,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1316, 1, 10, qba);
   suzuki_trotter([
@@ -5190,69 +5190,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0056, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -5260,27 +5260,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -5288,7 +5288,7 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1344, 1, 10, qba);
   suzuki_trotter([
@@ -5298,69 +5298,69 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.0709
+      coefficient=0.07093
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.1491
+      coefficient=0.14909
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.0891
+      coefficient=-0.08912
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.2324
+      coefficient=-0.23242
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.1332
+      coefficient=0.13317
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=-0.1919
+      coefficient=-0.19189
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.0232
+      coefficient=0.02316
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-0.1993
+      coefficient=-0.19934
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.0587
+      coefficient=0.05873
     }
   ], 0.0028, 1, 1, qba);
   suzuki_trotter([
     PauliTerm {
       pauli=[1, 0, 0],
-      coefficient=1.8513
+      coefficient=1.85132
     },
     PauliTerm {
       pauli=[1, 0, 3],
-      coefficient=0.482
+      coefficient=0.48201
     },
     PauliTerm {
       pauli=[1, 3, 0],
-      coefficient=0.9109
+      coefficient=0.91088
     },
     PauliTerm {
       pauli=[1, 3, 3],
-      coefficient=-0.1574
+      coefficient=-0.15736
     },
     PauliTerm {
       pauli=[1, 0, 1],
-      coefficient=-0.1797
+      coefficient=-0.17969
     },
     PauliTerm {
       pauli=[1, 3, 1],
-      coefficient=0.4617
+      coefficient=0.46175
     },
     PauliTerm {
       pauli=[2, 0, 2],
-      coefficient=0.2868
+      coefficient=0.28681
     },
     PauliTerm {
       pauli=[2, 3, 2],
@@ -5368,27 +5368,27 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[1, 1, 0],
-      coefficient=0.397
+      coefficient=0.39702
     },
     PauliTerm {
       pauli=[1, 1, 3],
-      coefficient=0.4549
+      coefficient=0.45492
     },
     PauliTerm {
       pauli=[2, 2, 0],
-      coefficient=0.275
+      coefficient=0.27502
     },
     PauliTerm {
       pauli=[2, 2, 3],
-      coefficient=-0.1294
+      coefficient=-0.12945
     },
     PauliTerm {
       pauli=[1, 1, 1],
-      coefficient=-1.1385
+      coefficient=-1.13854
     },
     PauliTerm {
       pauli=[1, 2, 2],
-      coefficient=0.2428
+      coefficient=0.24276
     },
     PauliTerm {
       pauli=[2, 1, 2],
@@ -5396,17 +5396,17 @@ qfunc adiabatic_evolution_qfunc_expanded___0(qba: qbit[3]) {
     },
     PauliTerm {
       pauli=[2, 2, 1],
-      coefficient=0.3288
+      coefficient=0.32878
     }
   ], 0.1372, 1, 10, qba);
 }
 
 qfunc main(output qba: qbit[3]) {
   prepare_state([
-    0.1191,
-    0.0827,
-    0.239,
-    0.5591,
+    0.11911,
+    0.08271,
+    0.23904,
+    0.55914,
     0.0,
     0.0,
     0.0,

--- a/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.synthesis_options.json
+++ b/algorithms/aqc/solving_qlsp/solving_qlsp_with_aqc.synthesis_options.json
@@ -7,28 +7,28 @@
     "machine_precision": 8,
     "custom_hardware_settings": {
       "basis_gates": [
-        "sdg",
         "rx",
-        "z",
-        "cz",
-        "cy",
-        "y",
         "h",
-        "id",
-        "r",
-        "u",
-        "p",
-        "u1",
-        "tdg",
-        "t",
-        "u2",
-        "cx",
-        "sx",
-        "x",
-        "ry",
-        "s",
         "rz",
-        "sxdg"
+        "sx",
+        "p",
+        "x",
+        "s",
+        "u",
+        "sdg",
+        "cy",
+        "sxdg",
+        "cx",
+        "tdg",
+        "y",
+        "z",
+        "r",
+        "id",
+        "u1",
+        "t",
+        "ry",
+        "u2",
+        "cz"
       ],
       "is_symmetric_connectivity": true
     },
@@ -39,6 +39,6 @@
     "pretty_qasm": true,
     "transpilation_option": "auto optimize",
     "timeout_seconds": 300,
-    "random_seed": 521064679
+    "random_seed": 2572511402
   }
 }


### PR DESCRIPTION
### PR Description

Fixed qmod probability - sum in prepare_state should add up to 1 

### Some notes

- [ ] Please make sure that you placed the files in an appropriate folder
- [ ] And that the files have indicative names.

- [ ] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [ ] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
