### PR TITLE
Update RNG seed in DQI notebook

### DIFF
--- a/algorithms/dqi/dqi_max_xorsat.ipynb
+++ b/algorithms/dqi/dqi_max_xorsat.ipynb
@@ -560,7 +560,7 @@
     "NUM_NODES = 6\n",
     "GRAPH_DEGREE = 2\n",
     "\n",
-    "G = nx.random_regular_graph(d=GRAPH_DEGREE, n=NUM_NODES, seed=1)\n",
+    "G = nx.random_regular_graph(d=GRAPH_DEGREE, n=NUM_NODES, seed=np.random.default_rng(seed=11))\n",
     "\n",
     "B = nx.incidence_matrix(G).T.toarray()\n",
     "v = np.ones(B.shape[0])\n",


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

The DQI notebook constructs a random graph with `seed=0`.

When NetwrokX encounters an `int` seed, it creates a Python RNG. However, Python's RNG does not guarantee to be consistent across platforms https://stackoverflow.com/questions/8786084/reproducibility-of-python-pseudo-random-numbers-across-systems-and-versions.

So instead, I set the notebook to explicitly allocate a Numpy RNG, which does provide this guarantee https://stackoverflow.com/questions/40676205/cross-platform-numpy-random-seed.

Using `np.default_rng(seed=11)` specifically ensures that the matrix B is generated the same way it was generated when the notebook was written.

### Some notes

- [ ] Please make sure that you placed the files in an appropriate folder
- [ ] And that the files have indicative names.

- [ ] Please note that Classiq runs automatic code linting, which may minorly alter some files.
  - [ ] If you're familiar with `pre-commit`, you may run `pre-commit install`, and then at each commit, your files will be altered in a similar way
