### PR TITLE
fix: update broken links to LCU tutorial

### DIFF
--- a/tutorials/basic_tutorials/hamiltonian_simulation/hamiltonian_simulation_with_block_encoding/hamiltonian_simulation_with_block_encoding.ipynb
+++ b/tutorials/basic_tutorials/hamiltonian_simulation/hamiltonian_simulation_with_block_encoding/hamiltonian_simulation_with_block_encoding.ipynb
@@ -13,7 +13,7 @@
    "id": "b5eab786-f4d8-4a89-b3f7-2355b46d4246",
    "metadata": {},
    "source": [
-    "This tutorial demonstrates how to implement Hamiltonian simulation for block-encoded Hamiltonians using two different techniques: Quantum Singular Eigenvalues Transform (QSVT) and qubitization. It specializes for a [Linear Combination of Unitaries (LCU)](https://github.com/Classiq/classiq-library/blob/main/tutorials/classiq_101/quantum_primitives/linear_combination_of_unitaries/linear_combination_of_unitaries.ipynb) block-encoding for the Hamiltonian; however, you can  easily modify the implementation of the Hamiltonian simulation to other block-encoding implementations.\n",
+    "This tutorial demonstrates how to implement Hamiltonian simulation for block-encoded Hamiltonians using two different techniques: Quantum Singular Eigenvalues Transform (QSVT) and qubitization. It specializes for a [Linear Combination of Unitaries (LCU)](https://github.com/Classiq/classiq-library/blob/main/tutorials/basic_tutorials/quantum_primitives/linear_combination_of_unitaries/linear_combination_of_unitaries.ipynb) block-encoding for the Hamiltonian; however, you can  easily modify the implementation of the Hamiltonian simulation to other block-encoding implementations.\n",
     "\n",
     "The tutorial is organized as follows: \n",
     "\n",
@@ -77,7 +77,7 @@
     "* & *\n",
     "\\end{pmatrix}, \\text{   for     } A = \\sum^{L-1}_{i=0} \\alpha_i U_i, \\,\\,\\,\\,\\, \\alpha_i\\geq 0\n",
     "$$\n",
-    "with $\\bar{\\alpha}\\equiv\\sum^{L-1}_{i=0}\\alpha_i$ and $m= \\lceil\\log_2(L) \\rceil$. See the [LCU tutorial](https://github.com/Classiq/classiq-library/blob/main/tutorials/classiq_101/quantum_primitives/linear_combination_of_unitaries/linear_combination_of_unitaries.ipynb) for more details.\n",
+    "with $\\bar{\\alpha}\\equiv\\sum^{L-1}_{i=0}\\alpha_i$ and $m= \\lceil\\log_2(L) \\rceil$. See the [LCU tutorial](https://github.com/Classiq/classiq-library/blob/main/tutorials/basic_tutorials/quantum_primitives/linear_combination_of_unitaries/linear_combination_of_unitaries.ipynb) for more details.\n",
     "\n",
     "\n",
     "This tutorial starts with an exact $(s, m, 0)$-encoding of some Hamiltonian and implements an approximated encoding of its Hamiltonian evolution\n",


### PR DESCRIPTION
- Fixed broken links in hamiltonian_simulation_with_block_encoding.ipynb
- Updated paths from classiq_101/quantum_primitives to basic_tutorials/quantum_primitives
- Resolves CI test_links failure

### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
