### PR TITLE
Use wildcard in auto-generated image names

### DIFF
--- a/.internal/paths_for_docs.yaml
+++ b/.internal/paths_for_docs.yaml
@@ -7,7 +7,7 @@ workshops: tutorials/workshops/
 qmod_core_library: functions/qmod_library_reference/qmod_core_library
 classiq_open_library: functions/qmod_library_reference/classiq_open_library
 qml_with_classiq_guide.ipynb: tutorials/basic_tutorials/qml_with_classiq_guide/qml_with_classiq_guide.ipynb
-output_17_0.converted.png: tutorials/basic_tutorials/qml_with_classiq_guide/output_17_0.converted.png
+qml_image.png: tutorials/basic_tutorials/qml_with_classiq_guide/*.png
 hamiltonian_simulation_guide.ipynb: tutorials/basic_tutorials/hamiltonian_simulation/hamiltonian_simulation_guide/hamiltonian_simulation_guide.ipynb
-output_37_0.converted.png: tutorials/basic_tutorials/hamiltonian_simulation/hamiltonian_simulation_guide/output_37_0.converted.png
+hamiltonian_image.png: tutorials/basic_tutorials/hamiltonian_simulation/hamiltonian_simulation_guide/*.png
 hadamard_test.ipynb: tutorials/basic_tutorials/quantum_primitives/hadamard_test/hadamard_test.ipynb

--- a/tests/internal/test_paths_for_docs.py
+++ b/tests/internal/test_paths_for_docs.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 
@@ -7,6 +6,7 @@ import yaml
 ROOT = Path(subprocess.getoutput("git rev-parse --show-toplevel"))  # noqa: S605
 PATHS_FOR_DOCS = ROOT / ".internal" / "paths_for_docs.yaml"
 DOCS_DIRECTORIES = ROOT / ".internal" / "docs_directories.txt"
+IMAGE_WILDCARD = "*.png"
 
 """
 This test checks if all paths in the files_to_copy_for_docs.yaml file exist.
@@ -23,7 +23,7 @@ def test_paths_to_copy_for_docs():
     for path in paths_to_copy.values():
         # png files are byproduct of the conversion from Jupyter to Markdown and cannot
         # be checked for existence in advance
-        if not (ROOT / path).exists() and Path(path).suffix != ".png":
+        if Path(path).name != IMAGE_WILDCARD and not (ROOT / path).exists():
             missing_paths.append(path)
 
     assert not missing_paths, f"The following paths do not exist: {missing_paths}"


### PR DESCRIPTION
### PR Description

Use `"*.png"` as name for auto-generated images, to avoid the need of hard-coding the name