### PR TITLE
Replace eqnarray with aligned

### DIFF
--- a/algorithms/amplitude_estimation/qmc_user_defined/qmc_user_defined.ipynb
+++ b/algorithms/amplitude_estimation/qmc_user_defined/qmc_user_defined.ipynb
@@ -64,9 +64,7 @@
    "cell_type": "markdown",
    "id": "c810e0d5-6fda-4868-aab9-ff036ff8974e",
    "metadata": {},
-   "source": [
-    "## 1. Building the Corresponding Grover Operator "
-   ]
+   "source": "## 1. Building the Corresponding Grover Operator"
   },
   {
    "cell_type": "code",
@@ -95,7 +93,7 @@
     "$$\n",
     "with $S_0$ and $S_{\\psi_1}$ being reflection operators around the zero state $|0\\rangle_n|0\\rangle$ and the good-state $|\\psi_1\\rangle$, respectively, and the function $A$ is defined in Eq. ([2](#mjx-eqn-2)).\n",
     "\n",
-    "In subsections (1.1)-(1.3) below we build each of the quantum sub-functions, and then in subsection (1.4) we combine them to define a complete Grover operator. On the way we introduce several concepts of functional modeling, which allow the Classiq synthesis engine to reach better optimized circuits. "
+    "In subsections (1.1)-(1.3) below we build each of the quantum sub-functions, and then in subsection (1.4) we combine them to define a complete Grover operator. On the way we introduce several concepts of functional modeling, which allow the Classiq synthesis engine to reach better optimized circuits."
    ]
   },
   {
@@ -113,9 +111,9 @@
    "id": "f9d562d6-0e6b-47ff-a130-1cd243ebdc61",
    "metadata": {},
    "source": [
-    "The function's signature declares two arguments: \n",
+    "The function's signature declares two arguments:\n",
     "1. A quantum register `x` declared as `QArray` (an array of qubits with an unspecified size) that is used to represent the discretization of space.\n",
-    "2. A quantum register `ind` of size 1 declared as `QBit` to indicate the good state. "
+    "2. A quantum register `ind` of size 1 declared as `QBit` to indicate the good state."
    ]
   },
   {
@@ -123,10 +121,10 @@
    "id": "5231c34a-89d9-433a-a85d-56517475f7f3",
    "metadata": {},
    "source": [
-    "Next, we construct the logic flow of the `state_loading` function. \n",
+    "Next, we construct the logic flow of the `state_loading` function.\n",
     "The function body consists of two quantum function calls:\n",
     "\n",
-    "1. As can be seen from Eq. ([2](#mjx-eqn-2)), the `load_probabilities` function is constructed using the Classiq `inplace_prepare_state` function call on $n=3$ qubits with probabilities $p_i$. \n",
+    "1. As can be seen from Eq. ([2](#mjx-eqn-2)), the `load_probabilities` function is constructed using the Classiq `inplace_prepare_state` function call on $n=3$ qubits with probabilities $p_i$.\n",
     "2. The `amplitude_loading` body calls the Classiq `linear_pauli_rotations` function. The `linear_pauli_rotations` loads the amplitude of the function $ f(x) = sin^2(0.25 x + 0.2) $.\n",
     "\n",
     "    *Note: The amplitude should be $sin$ so the probability is $sin^2$.*\n",
@@ -220,7 +218,7 @@
    "source": [
     "#### 1.2) $S_{\\psi_1}$ Function - The Good State Oracle\n",
     "\n",
-    "The next quantum function we define is the one that reflects around the good state: any $n+1$ state in which the `ind` register is at state $|1\\rangle$. This function can be constructed with a ZGate on the `ind` register. \n"
+    "The next quantum function we define is the one that reflects around the good state: any $n+1$ state in which the `ind` register is at state $|1\\rangle$. This function can be constructed with a ZGate on the `ind` register.\n"
    ]
   },
   {
@@ -246,7 +244,7 @@
     "\n",
     "To implement the Grover Diffuser we aim to perform a controlled-Z operation on the $|0>^n$ state.\n",
     "\n",
-    "We can define a `zero_oracle` quantum function with the `x` and `ind` registers as its arguments. \n",
+    "We can define a `zero_oracle` quantum function with the `x` and `ind` registers as its arguments.\n",
     "\n",
     "The `within_apply` operator takes two function arguments—compute and action—and invokes the sequence `compute()`, `action()`, and `invert(compute())`. Quantum objects that are allocated and prepared by compute are subsequently uncomputed and released.\n"
    ]
@@ -276,12 +274,12 @@
    "source": [
     "The inplace xor operation, `ind ^= x==0`, is equivalent to `control(x==0, X(ind))`.\n",
     "We can verify that\n",
-    "\\begin{eqnarray}\n",
+    "\\begin{aligned}\n",
     "|00\\dots0\\rangle \\xrightarrow[{\\rm ctrl(-Z)(target=q_0, ctrl=q_1\\dots q_n)}]{} -|00\\dots0\\rangle, \\\\\n",
     "|10\\dots0\\rangle \\xrightarrow[{\\rm ctrl(-Z)(target=q_0, ctrl=q_1\\dots q_n)}]{} |10\\dots0\\rangle, \\\\\n",
     "|11\\dots0\\rangle \\xrightarrow[{\\rm ctrl(-Z)(target=q_0, ctrl=q_1\\dots q_n)}]{} |11\\dots0\\rangle,\\\\\n",
     "|11\\dots1\\rangle \\xrightarrow[{\\rm ctrl(-Z)(target=q_0, ctrl=q_1\\dots q_n)}]{} |11\\dots1\\rangle,\n",
-    "\\end{eqnarray}\n",
+    "\\end{aligned}\n",
     "which is exactly the functionality we want.\n",
     "\n"
    ]
@@ -298,9 +296,9 @@
     "2. THe inverse of the state preparation (`state_loading`)\n",
     "3. The diffuser (`zero_oracle`)\n",
     "4. The state preparation (`state_loading`)\n",
-    " \n",
+    "\n",
     "*Note:*\n",
-    "- *Stages 2-4 are implemented by utilizing the `within_apply` operator*  \n",
+    "- *Stages 2-4 are implemented by utilizing the `within_apply` operator*\n",
     "- *We add a global phase of -1 to the full operator by using the atomic gate level function `U`*"
    ]
   },
@@ -388,9 +386,7 @@
    "cell_type": "markdown",
    "id": "e0605069-5062-4f01-92f8-a6b599c7e4bd",
    "metadata": {},
-   "source": [
-    "Below is the `main` function from which we can build our model and synthesize it. In particular, we define the output register `phase` as `QNum` to hold the phase register output of the QPE. We choose a QPE with phase register of size 3, governing the accuracy of our phase-, and thus amplitude-, estimation. "
-   ]
+   "source": "Below is the `main` function from which we can build our model and synthesize it. In particular, we define the output register `phase` as `QNum` to hold the phase register output of the QPE. We choose a QPE with phase register of size 3, governing the accuracy of our phase-, and thus amplitude-, estimation."
   },
   {
    "cell_type": "code",

--- a/algorithms/bernstein_vazirani/bernstein_vazirani.ipynb
+++ b/algorithms/bernstein_vazirani/bernstein_vazirani.ipynb
@@ -41,14 +41,14 @@
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "Problem hardness: Classically, the minimum inquiries of the function $f$ for determining the secret string is $n$: $f$ is called with these strings: \n",
+    "Problem hardness: Classically, the minimum inquiries of the function $f$ for determining the secret string is $n$: $f$ is called with these strings:\n",
     "$$\n",
-    "\\begin{eqnarray}\n",
-    "f(100\\dots0) &=& a_0, \\\\\n",
-    "f(010\\dots0) &=& a_1, \\\\\n",
+    "\\begin{aligned}\n",
+    "f(100\\dots0) &= a_0, \\\\\n",
+    "f(010\\dots0) &= a_1, \\\\\n",
     "\\vdots\\\\\n",
-    "f(00\\dots01)&=& a_{n-1},\n",
-    "\\end{eqnarray}\n",
+    "f(00\\dots01) &= a_{n-1},\n",
+    "\\end{aligned}\n",
     "$$\n",
     "which reveals the secret string, one bit at a time. **The BV algorithm finds the secret string using one function call (oracle inquiry), thereby providing a linear speedup with respect to the classical solution.**"
    ]
@@ -306,7 +306,7 @@
     "$$\n",
     "Finally, application of the Hadamard transform, which can be written as $H^{\\otimes n}\\equiv \\frac{1}{2^{n/2}}\\sum^{2^n-1}_{k,l=0}(-1)^{k\\cdot l} |k\\rangle \\langle l| $, gives\n",
     "$$\n",
-    "\\frac{1}{2^{n/2}}\\sum^{2^n-1}_{j=0}(-1)^{a\\cdot j}|j\\rangle  \\xrightarrow[H^{\\otimes n}]{} \n",
+    "\\frac{1}{2^{n/2}}\\sum^{2^n-1}_{j=0}(-1)^{a\\cdot j}|j\\rangle  \\xrightarrow[H^{\\otimes n}]{}\n",
     "\\sum^{2^n-1}_{k=0} \\left(\\frac{1}{2^{n}}\\sum^{2^n-1}_{j=0}(-1)^{j\\cdot \\left(k\\oplus a \\right)} \\right) |k\\rangle.\n",
     "$$\n",
     "The final expression represents a superposition over all basis states $|k\\rangle$; however, we can verify that the amplitude of the state $|k\\rangle=|a\\rangle$ is simply one, as $a\\oplus a =0$:\n",


### PR DESCRIPTION
As KaTeX doesn't fully support LaTeX (specifically `eqnarray` - https://github.com/KaTeX/KaTeX/issues/3643), replace `eqnarray` with `aligned`. Thus, we ensure it renders in more environments, e.g., web vscode.

There are 2 cases I found:

- `qmc_user_defined.ipynb`.
- For `bernstein_vazirani.ipynb`, I also removed `&` after `=` to keep the right part aligned to the left, just as before.

The rest of the changes are just auto-formatting, mostly removing trailing spaces, etc.