### PR TITLE
Exclude internal documentation from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   python: python3.11
+exclude: '^\.internal/docs/.*' # exclude docs from pre-commit hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
### PR Description
The contents of `.internal/docs` is copied as-is from the Classiq docs which follow different linters. Furthermore, they should not be edited by anything other than the sync workflow with is auto-approved.
As such, they can be ignored by the pre-commit hooks.