### PR TITLE
Split test_links to run twice, based on env-var

### DIFF
--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -163,6 +163,8 @@ jobs:
           SHOULD_TEST_ALL_FILES: "true" # quick tests should run all files
           LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
           LIST_OF_IPYNB_TESTS_CHANGED: "${{ steps.changed-files-tests.outputs.all_changed_files }}"
+          # Altering test behavior
+          LIMIT_TEST_LINKS_TO_FILES_ONLY: "true"
           # Passing environment information
           CLASSIQ_IDE: "https://platform.classiq.io"
           CLASSIQ_HOST: "https://api.classiq.io"
@@ -176,6 +178,8 @@ jobs:
           SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
           LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
           LIST_OF_IPYNB_TESTS_CHANGED: "${{ steps.changed-files-tests.outputs.all_changed_files }}"
+          # Altering test behavior
+          LIMIT_TEST_LINKS_TO_FILES_ONLY: "false"
           # Passing environment information
           CLASSIQ_IDE: "https://platform.classiq.io"
           CLASSIQ_HOST: "https://api.classiq.io"

--- a/tests/config_notebook_execute_tests.ini
+++ b/tests/config_notebook_execute_tests.ini
@@ -1,4 +1,5 @@
 [pytest]
 testpaths =
     tests/notebooks
+    tests/test_links
 addopts = --log-cli-level=INFO --durations=0

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,3 +1,4 @@
+import os
 import re
 import time
 from collections.abc import Iterable
@@ -69,10 +70,13 @@ def _test_single_url(
     use_head: bool = True,
     follow_redirects: bool = True,
 ) -> bool:
-    if any(url.startswith(allowed) for allowed in get_url_allow_list()):
+    if check_file_instead_of_url(url):
         return True
 
-    if check_file_instead_of_url(url):
+    if os.environ.get("LIMIT_TEST_LINKS_TO_FILES_ONLY", "false").lower() == "true":
+        return True  # if we only wish to check files, then we end this test here.
+
+    if any(url.startswith(allowed) for allowed in get_url_allow_list()):
         return True
 
     if retry == 0:


### PR DESCRIPTION
In the "run against all notebooks" mode, we test all the links, but only check links which are actually files in this repo, so the test is quick.
In the "run against changed notebooks" mode, we test all the links.

Thus, a PR that changes one notebook should no longer fail due to a broken link in another notebook
