### PR TITLE
update readme 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Whether you're a researcher, developer, or student, Classiq helps you simplify c
    &emsp;|&emsp;
    <a href="https://docs.classiq.io/latest/">📖 Documentation</a>
    &emsp; | &emsp;
-   <a href="https://docs.classiq.io/latest/">Getting Started</a>
+   <a href="https://docs.classiq.io/latest/classiq_101/">Getting Started</a>
    &emsp;
 </p>
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ With Classiq, you can build anything. Classiq provides a powerful modeling langu
 
 ## SDK : Classiq's Python Interface
 
-### Example: 3+5 with Classiq
+### Example: Calculating 3+5 with Classiq
 
 ```python
 from classiq import (

--- a/README.md
+++ b/README.md
@@ -222,14 +222,14 @@ from classiq import *
 
 
 @qfunc
-def get_3(x: Output[QArray]) -> None:
+def prepare_3(x: Output[QArray]) -> None:
     allocate(2, x)
     X(x[0])
     X(x[1])
 
 
 @qfunc
-def get_5(x: Output[QArray]) -> None:
+def prepare_5(x: Output[QArray]) -> None:
     allocate(3, x)
     X(x[0])
     X(x[2])
@@ -239,8 +239,8 @@ def get_5(x: Output[QArray]) -> None:
 def main(res: Output[QNum]) -> None:
     a = QNum("a")
     b = QNum("b")
-    get_3(a)
-    get_5(b)
+    prepare_3(a)
+    prepare_5(b)
     res |= a + b  # should be 8
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This repository has 2 kinds of demos: `.qmod` and `.ipynb`.
 The `.qmod` files are intended for usage with [Classiq's platform](https://platform.classiq.io/).
 Upload those `.qmod` files into the [Synthesis tab](https://platform.classiq.io/synthesis)
 
-The `.ipynb` files are intended to be viewed inside [JupyterLab](https://jupyter.org/).
+The `.ipynb` files are intended to be viewed inside [JupyterLab](https://jupyter.org/) (or by programs that support such files, such as VSCode).
 
 # Create Quantum Programs with Classiq
 
@@ -90,9 +90,8 @@ print(result.dataframe)
 Let's unravel the code above:
 
 1. `def main` : We define the logic of our quantum program. We'll expand on this point soon below.
-2. `create_model` : We convert the logic we defined into a Model.
-3. `synthesize` : We synthesize the Model into a Quantum Program. From a logical definition of quantum operations, into a series of quantum gates.
-4. `execute` : Executing the quantum program. Can be executed on a physical quantum computer, or on simulations.
+2. `synthesize` : We synthesize the logic we defined into a Quantum Program. From a logical definition of quantum operations, into a series of quantum gates.
+3. `execute` : Executing the quantum program. Can be executed on a physical quantum computer, or on simulations. Defaults to simulations.
 
 ## 1) Defining the Logic of Quantum Programs
 
@@ -149,26 +148,16 @@ def angle_encoding(exe_params: CArray[CReal], qbv: Output[QArray[QBit]]) -> None
 
 For more, see this repository :)
 
-## 2) Logic to Models
-
-As we saw above, the `main` function can be converted to a model using `model = create_model(main)`.
-
-A model is built out of 2 parts: a `qmod`, and `synthesis options`.
-The former is a quantum language used for defining quantum programs, while the latter is a configuration for the execution of the program.
-
-The model can be saved via `write_qmod(model, "file_name")`, which will save 2 files: `file_name.qmod` and `file_name.synthesis_options.json`.
-You may encounter these files in this repository.
-
-## 3) Synthesis : Models to Quantum Program
+## 2) Synthesis : Logic to Quantum Program
 
 This is where the magic happens.
-Taking a model, which is a set of logical operations, and synthesizing it into physical qubits and the gates entangling them, is not an easy task.
+Taking a the `main` function, which is a set of logical operations, and synthesizing it into physical qubits and the gates entangling them, is not an easy task.
 
 Classiq's synthesis engine is able to optimize this process, whether by requiring the minimal amount of physical qubits, thus reusing as many qubits as possible, or by requiring minimal circuit width, thus lowering execution time and possible errors.
 
-## 4) Execution
+## 3) Execution
 
-Classiq provides an easy-to-use way to execute quantum programs, and provides various insights of the execution results.
+Classiq provides an easy-to-use way to execute quantum programs, and provides various insights of the execution results together with a familiar interface: `pandas.DataFrame`.
 
 ## Diagrams
 
@@ -260,7 +249,7 @@ print(result.dataframe)
 
 ## IDE : Classiq's Platform
 
-The examples found in this repository can be accessed via [Classiq's platform](https://platform.classiq.io/), in the [`model`](https://platform.classiq.io/dsl-synthesis) tab, under the same folder structure.
+Every example found in this repository can also be accessed via [Classiq's platform](https://platform.classiq.io/), in the [`model`](https://platform.classiq.io/dsl-synthesis) tab, under the same folder structure.
 
 Additionally, one may write their own model in the model editor (highlighted in green) or upload his own model (highlighted in red)
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,12 @@ quantum_program = synthesize(main)
 show(quantum_program)
 
 result = execute(quantum_program).result_value()
-print(result.parsed_counts)
-# [{'res': 1}: 2048]
+print(result.dataframe)
 ```
+
+|     | res | count | probability | bitstring |
+| --: | --: | ----: | ----------: | --------: |
+|   0 |   1 |  2048 |           1 |         1 |
 
 Let's unravel the code above:
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,11 @@ def prepare_5(var: Output[QArray]) -> None:
 def main(res: Output[QNum]) -> None:
     a = QNum("a")
     b = QNum("b")
+
     prepare_3(a)
     prepare_5(b)
-    res |= a + b  # should be 8
+
+    res |= a + b  # 3+5 should be 8
 
 
 model = create_model(main)

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ quantum_program = synthesize(main)
 
 show(quantum_program)
 
-result = execute(quantum_program).result()
-print(result[0].value.parsed_counts)
+result = execute(quantum_program).result_value()
+print(result.parsed_counts)
 # [{'res': 1}: 2048]
 ```
 

--- a/README.md
+++ b/README.md
@@ -218,18 +218,7 @@ With Classiq, you can build anything. Classiq provides a powerful modeling langu
 ### Example: Calculating 3+5 with Classiq
 
 ```python
-from classiq import (
-    QArray,
-    Output,
-    allocate,
-    qfunc,
-    X,
-    QNum,
-    synthesize,
-    create_model,
-    show,
-    execute,
-)
+from classiq import *
 
 
 @qfunc

--- a/README.md
+++ b/README.md
@@ -246,8 +246,7 @@ def main(res: Output[QNum]) -> None:
     res |= a + b  # 3+5 should be 8
 
 
-model = create_model(main)
-quantum_program = synthesize(model)
+quantum_program = synthesize(main)
 
 show(quantum_program)
 

--- a/README.md
+++ b/README.md
@@ -251,8 +251,12 @@ quantum_program = synthesize(main)
 show(quantum_program)
 
 result = execute(quantum_program).result_value()
-print(result.parsed_counts)
+print(result.dataframe)
 ```
+
+|     | res | count | probability | bitstring |
+| --: | --: | ----: | ----------: | --------: |
+|   0 |   8 |  2048 |           1 |      1000 |
 
 ## IDE : Classiq's Platform
 

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ quantum_program = synthesize(main)
 
 show(quantum_program)
 
-result = execute(quantum_program).result()
-print(result[0].value.parsed_counts)
+result = execute(quantum_program).result_value()
+print(result.parsed_counts)
 ```
 
 ## IDE : Classiq's Platform

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ def main(res: Output[QBit]):
     X(res)
 
 
-model = create_model(main)
-quantum_program = synthesize(model)
+quantum_program = synthesize(main)
 
 show(quantum_program)
 

--- a/README.md
+++ b/README.md
@@ -222,17 +222,17 @@ from classiq import *
 
 
 @qfunc
-def prepare_3(x: Output[QArray]) -> None:
-    allocate(2, x)
-    X(x[0])
-    X(x[1])
+def prepare_3(var: Output[QArray]) -> None:
+    allocate(2, var)
+    X(var[0])
+    X(var[1])
 
 
 @qfunc
-def prepare_5(x: Output[QArray]) -> None:
-    allocate(3, x)
-    X(x[0])
-    X(x[2])
+def prepare_5(var: Output[QArray]) -> None:
+    allocate(3, var)
+    X(var[0])
+    X(var[2])
 
 
 @qfunc


### PR DESCRIPTION
- Update README: Update getting-started link
- Update README: Update example to use `synthesize(main)` directly
- Update README: Update example execution syntax
- Update README: Update example execution output to DataFrame
- Update README: Update example title
- Update README: Shorten example import
- Update README: Rename example functions to 'prepare' to follow the naming of 'state preparation'
- Update README: Rename example variable to 'var' to avoid 'X(x)' confusion
- Update README: Rename example comment
- Update README: Update example to use `synthesize(main)` directly
- Update README: Update example execution syntax
- Update README: Update example execution output to DataFrame
- Update README: Update text
