### PR TITLE
Fixing typos in execution tutorial

### DIFF
--- a/tutorials/basic_tutorials/the_classiq_tutorial/execution_tutorial_part2.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/execution_tutorial_part2.ipynb
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "f3f8a5bc",
    "metadata": {},
    "outputs": [],
@@ -231,7 +231,7 @@
     "projector_operator = 0.25 * (\n",
     "    Pauli.I(0) * Pauli.I(1)\n",
     "    + Pauli.X(0) * Pauli.X(1)\n",
-    "    + (-1) * Pauli.Y(0) * Pauli.Y(1)\n",
+    "    - Pauli.Y(0) * Pauli.Y(1)\n",
     "    + Pauli.Z(0) * Pauli.Z(1)\n",
     ")"
    ]
@@ -497,7 +497,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -511,7 +511,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There were some typos in the execution tutorial that needed a fix.