### PR TITLE
Fix `CLASSIQ_HOST` value in workflows

### DIFF
--- a/.github/workflows/Test-CI-daily-internal.yml
+++ b/.github/workflows/Test-CI-daily-internal.yml
@@ -41,4 +41,4 @@ jobs:
           SHOULD_TEST_ALL_FILES: "true"
           # Passing environment information
           CLASSIQ_IDE: "https://nightly.platform.classiq.io"
-          CLASSIQ_HOST: "https://staging.api.classiq.io"
+          CLASSIQ_HOST: "https://nightly.platform.classiq.io"

--- a/.github/workflows/Test-CI-daily-notebooks-algorithms.yml
+++ b/.github/workflows/Test-CI-daily-notebooks-algorithms.yml
@@ -49,4 +49,4 @@ jobs:
           LIST_OF_IPYNB_TESTS_CHANGED: ""
           # Passing environment information
           CLASSIQ_IDE: "https://nightly.platform.classiq.io"
-          CLASSIQ_HOST: "https://staging.api.classiq.io"
+          CLASSIQ_HOST: "https://nightly.platform.classiq.io"

--- a/.github/workflows/Test-CI-daily-notebooks-applications.yml
+++ b/.github/workflows/Test-CI-daily-notebooks-applications.yml
@@ -49,4 +49,4 @@ jobs:
           LIST_OF_IPYNB_TESTS_CHANGED: ""
           # Passing environment information
           CLASSIQ_IDE: "https://nightly.platform.classiq.io"
-          CLASSIQ_HOST: "https://staging.api.classiq.io"
+          CLASSIQ_HOST: "https://nightly.platform.classiq.io"

--- a/.github/workflows/Test-CI-daily-notebooks-other.yml
+++ b/.github/workflows/Test-CI-daily-notebooks-other.yml
@@ -41,4 +41,4 @@ jobs:
           SHOULD_TEST_ALL_FILES: "true"
           # Passing environment information
           CLASSIQ_IDE: "https://nightly.platform.classiq.io"
-          CLASSIQ_HOST: "https://staging.api.classiq.io"
+          CLASSIQ_HOST: "https://nightly.platform.classiq.io"

--- a/.github/workflows/Test-CI-daily-notebooks-tutorials.yml
+++ b/.github/workflows/Test-CI-daily-notebooks-tutorials.yml
@@ -49,4 +49,4 @@ jobs:
           LIST_OF_IPYNB_TESTS_CHANGED: ""
           # Passing environment information
           CLASSIQ_IDE: "https://nightly.platform.classiq.io"
-          CLASSIQ_HOST: "https://staging.api.classiq.io"
+          CLASSIQ_HOST: "https://nightly.platform.classiq.io"

--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -185,9 +185,6 @@ jobs:
           LIST_OF_IPYNB_TESTS_CHANGED: "${{ steps.changed-files-tests.outputs.all_changed_files }}"
           # Altering test behavior
           LIMIT_TEST_LINKS_TO_FILES_ONLY: "true"
-          # Passing environment information
-          CLASSIQ_IDE: "https://platform.classiq.io"
-          CLASSIQ_HOST: "https://api.classiq.io"
 
       - name: Run Notebooks (executing notebooks and testing content)
         run: python -m pytest -c tests/config_notebook_execute_tests.ini
@@ -201,6 +198,3 @@ jobs:
           LIST_OF_QMOD_CHANGED: "${{ steps.changed-files-qmod.outputs.all_changed_files }}"
           # Altering test behavior
           LIMIT_TEST_LINKS_TO_FILES_ONLY: "false"
-          # Passing environment information
-          CLASSIQ_IDE: "https://platform.classiq.io"
-          CLASSIQ_HOST: "https://api.classiq.io"


### PR DESCRIPTION
### PR Description

In main workflow just use default values
In weekly workflows set to `nightly.platform.classiq.io` and not directly to the API