### PR TITLE
Fixing Broken Link

### DIFF
--- a/tutorials/basic_tutorials/the_classiq_tutorial/classiq_overview_tutorial.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/classiq_overview_tutorial.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If this `import` doesn't work for you, please try `pip install classiq` in your terminal, or refer to [Registration and Installation](https://docs.classiq.io/latest/classiq_101/registration_installations/)."
+    "If this `import` doesn't work for you, please try `pip install classiq` in your terminal, or refer to [Registration and Installation](https://docs.classiq.io/latest/getting-started/registration_installations/)."
    ]
   },
   {
@@ -304,7 +304,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -318,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixing a broken link in the classiq overview tutorial due to the change latest/classiq_101 to latest/getting-started.