### PR TITLE
Fix hamiltonian_to_matrix usages

### DIFF
--- a/algorithms/hamiltonian_simulation/hamiltonian_simulation_with_block_encoding/hamiltonian_simulation_with_block_encoding.ipynb
+++ b/algorithms/hamiltonian_simulation/hamiltonian_simulation_with_block_encoding/hamiltonian_simulation_with_block_encoding.ipynb
@@ -462,7 +462,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "matrix = hamiltonian_to_matrix(HAMILTONIAN)"
+    "matrix = pauli_operator_to_matrix(HAMILTONIAN)"
    ]
   },
   {

--- a/algorithms/vqls/lcu_vqls/vqls_with_lcu.ipynb
+++ b/algorithms/vqls/lcu_vqls/vqls_with_lcu.ipynb
@@ -709,7 +709,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "A_num = hamiltonian_to_matrix(pauli_terms_structs) / normalization\n",
+    "A_num = pauli_operator_to_matrix(pauli_terms_structs) / normalization\n",
     "b = np.ones(8) / np.sqrt(8)"
    ]
   },

--- a/tutorials/advanced_tutorials/high_level_modeling_flexible_qpe/high_level_modeling_flexible_qpe.ipynb
+++ b/tutorials/advanced_tutorials/high_level_modeling_flexible_qpe/high_level_modeling_flexible_qpe.ipynb
@@ -268,7 +268,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "a_mat = hamiltonian_to_matrix(po).real\n",
+    "a_mat = pauli_operator_to_matrix(po).real\n",
     "w, v = np.linalg.eig(a_mat)\n",
     "\n",
     "chosen_eig = 2\n",
@@ -504,7 +504,7 @@
     "    my_qpe_flexible(\n",
     "        unitary=lambda arg0, arg1: unitary_with_power_logic(\n",
     "            matrix=scipy.linalg.expm(\n",
-    "                2 * np.pi * 1j * hamiltonian_to_matrix(po)\n",
+    "                2 * np.pi * 1j * pauli_operator_to_matrix(po)\n",
     "            ).tolist(),\n",
     "            pw=arg0,\n",
     "            target=arg1,\n",


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
