### PR TITLE
Removing an incorrect </div>

### DIFF
--- a/applications/chemistry/classiq_chemistry_application/classiq_chemistry_application.ipynb
+++ b/applications/chemistry/classiq_chemistry_application/classiq_chemistry_application.ipynb
@@ -367,8 +367,7 @@
    "id": "21",
    "metadata": {},
    "source": [
-    "><strong> HF state under the JW transform: :</strong> Working with the JW transform, there is a simple relation between the original Fock (occupation number) and transformed (computational) basis states: the state $|\\underbrace{0\\dots 0}_{k-1}10\\dots 0\\rangle$ corresponds to occupation of the $k$-th spin orbital in both spaces. Therefore, the Hartree Fock state under this transformation is the string $|\\underbrace{1\\dots 1}_{N_{\\alpha}}00\\dots 0\\underbrace{1\\dots 1}_{N_{\\beta}}0\\dots 0\\rangle$. (This is as opposed to the BK transform, that gives a different computational basis state).\n",
-    "</div>\n"
+    "><strong> HF state under the JW transform: :</strong> Working with the JW transform, there is a simple relation between the original Fock (occupation number) and transformed (computational) basis states: the state $|\\underbrace{0\\dots 0}_{k-1}10\\dots 0\\rangle$ corresponds to occupation of the $k$-th spin orbital in both spaces. Therefore, the Hartree Fock state under this transformation is the string $|\\underbrace{1\\dots 1}_{N_{\\alpha}}00\\dots 0\\underbrace{1\\dots 1}_{N_{\\beta}}0\\dots 0\\rangle$. (This is as opposed to the BK transform, that gives a different computational basis state).\n"
    ]
   },
   {


### PR DESCRIPTION
There is an extra `</div>` in this notebook that causes its page in the documentation look bad. This will fix it.