### PR TITLE
Replacing and by logical_and in the supported operators for arithmetics

### DIFF
--- a/functions/function_usage_examples/arithmetic/arithmetic_expression/arithmetic_expression_example.ipynb
+++ b/functions/function_usage_examples/arithmetic/arithmetic_expression/arithmetic_expression_example.ipynb
@@ -41,7 +41,7 @@
     "- Less Than: `<`\n",
     "- Less Or Equal: `<=`\n",
     "- Modulo: `%` limited for power of 2\n",
-    "- Logical And: `and`\n",
+    "- Logical And: `logical_and`\n",
     "- Logical Or: `or`\n",
     "- Max: `max` (n>=2 arguments)\n",
     "- Min: `min` (n>=2 arguments)\n",


### PR DESCRIPTION
### PR Description

Pythonic `and` is being indicated as a supported operator for arithmetics while the correct operator is `logical_and`. This PR replaces `and` to the correct version.
