### PR TITLE
support metadata for notebooks

### DIFF
--- a/.github/scripts/join_qmod_metadata.py
+++ b/.github/scripts/join_qmod_metadata.py
@@ -6,21 +6,33 @@ import sys
 from pathlib import Path
 from typing import List
 
-PYTHON_DIALECT = "python"
-NATIVE_DIALECT = "native"
+# Order matters: higher-priority suffixes first
+QMOD_DICT = {".qmod": "native", ".ipynb": "python"}
 
 
 def _get_qmod_path_for_metadata(metadata_path: Path) -> tuple[Path, str] | None:
-    # Each metadata file has the same name as the qmod file, but with a .json extension,
-    # so we replace the extension with qmod
-    native_qmod_path = metadata_path.parent / (Path(metadata_path.stem).stem + ".qmod")
-    if native_qmod_path.exists():
-        return native_qmod_path, NATIVE_DIALECT
-    python_qmod_path = metadata_path.parent / (Path(metadata_path.stem).stem + ".ipynb")
-    if python_qmod_path.exists():
-        return python_qmod_path, PYTHON_DIALECT
+    """
+    Locate a .qmod or .ipynb file corresponding to the given metadata file.
 
-    # it is the libraries responsibility to ensure that each metadata file has a corresponding qmod file
+    The metadata file is expected to have a .metadata.json suffix (e.g.,
+    "example.metadata.json"). This function strips the .metadata.json suffix
+    to get the base name, then looks for a matching .qmod or .ipynb file in
+    the same directory (e.g., "example.qmod" or "example.ipynb").
+
+    Files are checked in QMOD_DICT order:
+    (.qmod, native),
+    then (.ipynb, python).
+
+    Returns the matched file path and its dialect, or `None` if no match exists.
+    """
+    meta_data_base_name = f"{metadata_path.parent / Path(metadata_path.stem).stem}"
+
+    for suffix, dialect in QMOD_DICT.items():
+        print(f"base name: {meta_data_base_name}{suffix}")
+        if Path(f"{meta_data_base_name}{suffix}").exists():
+            return Path(f"{meta_data_base_name}{suffix}"), dialect
+
+    # it is the libraries responsibility to ensure that each metadata file has a corresponding qmod/ipynb file
     return None
 
 
@@ -36,9 +48,17 @@ def _is_json(data: str) -> bool:
     return True
 
 
+def _enrich_metadata_with_qmod_info(
+    single_metadata: dict, qmod_data: tuple[Path, str], directory: Path
+) -> None:
+    qmod_path, dialect = qmod_data
+    single_metadata["path"] = str(qmod_path.relative_to(directory))
+    single_metadata["qmod_dialect"] = dialect
+
+
 def join_metadata_files(directory: Path, exclude_file: Path) -> List[dict]:
     metadata = []
-    for metadata_path in sorted(directory.rglob("*.metadata.json")):
+    for metadata_path in directory.rglob("*.metadata.json"):
         if metadata_path == exclude_file:
             continue
         if metadata_path.suffixes == [".synthesis_options", ".json"]:
@@ -50,9 +70,7 @@ def join_metadata_files(directory: Path, exclude_file: Path) -> List[dict]:
         if qmod_data is None:
             continue
 
-        qmod_path, dialect = qmod_data
-        single_metadata["path"] = str(qmod_path.relative_to(directory))
-        single_metadata["qmod_dialect"] = dialect
+        _enrich_metadata_with_qmod_info(single_metadata, qmod_data, directory)
         metadata.append(single_metadata)
     return metadata
 


### PR DESCRIPTION
support metadata for notebooks

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
