### PR TITLE
Classiq Overview Tutorial -> Overview Tutorial

### DIFF
--- a/tutorials/basic_tutorials/the_classiq_tutorial/classiq_overview_tutorial.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/classiq_overview_tutorial.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Classiq Overview Tutorial\n",
+    "# Overview Tutorial\n",
     "\n",
     "In this notebook we introduce a typical workflow with Classiq:\n",
     "- **Designing a quantum model** using the Qmod language and it's accompanied function library.\n",


### PR DESCRIPTION
Changing the title of the Classiq Overview Tutorial simply to Overview Tutorial to temporarily reduce the usage of the "Classiq" word in the documentation.