### PR TITLE
Fix auto-uncomputation error in logical_qubits_by_alice_and_bob

### DIFF
--- a/community/basic_examples/logical_qubits/logical_qubits_by_alice_and_bob.ipynb
+++ b/community/basic_examples/logical_qubits/logical_qubits_by_alice_and_bob.ipynb
@@ -342,10 +342,11 @@
     "\n",
     "\n",
     "@qfunc\n",
-    "def main(test: Output[QBit]):\n",
-    "\n",
-    "    state1 = QArray()\n",
-    "    state2 = QArray()\n",
+    "def main(\n",
+    "    test: Output[QBit],\n",
+    "    state1: Output[QArray[QBit]],\n",
+    "    state2: Output[QArray[QBit]],\n",
+    "):\n",
     "    prepare_amplitudes(amps1.tolist(), 0.0, state1)\n",
     "    prepare_amplitudes(amps2.tolist(), 0.0, state2)\n",
     "    swap_test(state1, state2, test)"
@@ -444,7 +445,10 @@
    "outputs": [],
    "source": [
     "def results_error_rate(res):\n",
-    "    return 1 - res[0].value.counts[\"0\"] / sum(res[0].value.counts.values())"
+    "    parsed = res[0].value.parsed_counts\n",
+    "    test_zero_shots = sum(sample.shots for sample in parsed if sample.state[\"test\"] == 0)\n",
+    "    total_shots = sum(sample.shots for sample in parsed)\n",
+    "    return 1 - test_zero_shots / total_shots"
    ]
   },
   {


### PR DESCRIPTION
Cell 18's main() declared state1/state2 as local QArrays initialized by prepare_amplitudes (a non-permutation operation), so they cannot be auto-uncomputed when they go out of scope. Synthesis now rejects this unconditionally (auto-uncomputation validation is always-on).

Move state1/state2 to Output parameters of main so they are owned by the caller. Update results_error_rate to filter on the test register via parsed_counts: counts["0"] would now require every output qubit to be 0, which is no longer the same as P(test=0).

### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
