### PR TITLE
Fix auto-uncomputation error in logical_qubits_by_alice_and_bob

### DIFF
--- a/community/basic_examples/logical_qubits/logical_qubits_by_alice_and_bob.ipynb
+++ b/community/basic_examples/logical_qubits/logical_qubits_by_alice_and_bob.ipynb
@@ -348,7 +348,9 @@
     "    state2 = QArray()\n",
     "    prepare_amplitudes(amps1.tolist(), 0.0, state1)\n",
     "    prepare_amplitudes(amps2.tolist(), 0.0, state2)\n",
-    "    swap_test(state1, state2, test)"
+    "    swap_test(state1, state2, test)\n",
+    "    drop(state1)\n",
+    "    drop(state2)"
    ]
   },
   {


### PR DESCRIPTION
Cell 18's main() declared state1/state2 as local QArrays initialized by prepare_amplitudes (a non-permutation operation), so they cannot be auto-uncomputed when they go out of scope. Synthesis now rejects this unconditionally (auto-uncomputation validation is always-on).

Move state1/state2 to Output parameters of main so they are owned by the caller. Update results_error_rate to filter on the test register via parsed_counts: counts["0"] would now require every output qubit to be 0, which is no longer the same as P(test=0).

### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [x] Please make sure that the notebook runs successfully with the latest Classiq version.

- [x] Please make sure that you placed the files in an appropriate folder

  - [x] And that the file names are clear, descriptive, and match the notebook content.
    - [x] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [x] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [x] And that images are embedded inside the notebook, not added as external files

- [x] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [x] Please use `rebase` on your branch (no merge commits)
- [x] Please link this PR to the relevant issue

- [x] Please make sure to run `pre-commit` when commiting changes
  - [x] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [x] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [x] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [x] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
