### PR TITLE
Update Shor synthesis optimization_parameter to width

### DIFF
--- a/algorithms/number_theory_and_cryptography/shor/shor.synthesis_options.json
+++ b/algorithms/number_theory_and_cryptography/shor/shor.synthesis_options.json
@@ -1,7 +1,7 @@
 {
   "constraints": {
     "max_gate_count": {},
-    "optimization_parameter": "no_opt"
+    "optimization_parameter": "width"
   },
   "preferences": {
     "custom_hardware_settings": {


### PR DESCRIPTION
## Summary
- Update `algorithms/number_theory_and_cryptography/shor/shor.synthesis_options.json` so `optimization_parameter` is `"width"`, matching the notebook's `Constraints(optimization_parameter="width")` in `shor.ipynb`.

## Test plan
- [ ] CI synthesis test for the Shor notebook passes with the new constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)