### PR TITLE
CLS-7828: Bind num_kicks via assign_parameters before reading transpi…

### DIFF
--- a/applications/physical_systems/quantum_chaos/quantum_sawtooth_map.ipynb
+++ b/applications/physical_systems/quantum_chaos/quantum_sawtooth_map.ipynb
@@ -272,8 +272,9 @@
     }
    ],
    "source": [
-    "depth = qprog.transpiled_circuit.depth\n",
-    "cx_counts = qprog.transpiled_circuit.count_ops[\"cx\"]\n",
+    "ap_qprog = assign_parameters(qprog, {\"num_kicks\": 1})\n",
+    "depth = ap_qprog.transpiled_circuit.depth\n",
+    "cx_counts = ap_qprog.transpiled_circuit.count_ops[\"cx\"]\n",
     "print(f\"depth for one iteration {depth}\")\n",
     "print(f\"cx counts for one iteration {cx_counts}\")"
    ]


### PR DESCRIPTION
…led metrics

Reading qprog.transpiled_circuit on the parametric program fails in the new synthesis flow, where the metrics are computed lazily via export and the structural num_kicks power count must be bound first. Assign num_kicks=1 and read depth/cx counts from the resulting non-parametric program.

### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
