### PR TITLE
Regenerate exponentiation qmod from notebook

### DIFF
--- a/tutorials/basic_tutorials/exponentiation/example_exponentiation.qmod
+++ b/tutorials/basic_tutorials/exponentiation/example_exponentiation.qmod
@@ -1,135 +1,14255 @@
 qfunc main(output state: qbit[]) {
-  allocate(8, state);
-  exponentiation_with_depth_constraint([
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::Z,
-        Pauli::Z,
-        Pauli::Y,
-        Pauli::X
-      ],
-      coefficient=0.3
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::X,
-        Pauli::Z,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::X
-      ],
-      coefficient=0.4
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::X,
-        Pauli::Y
-      ],
-      coefficient=0.7
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::Z,
-        Pauli::Y
-      ],
-      coefficient=0.6
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::X,
-        Pauli::Z
-      ],
-      coefficient=0.9
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I,
-        Pauli::Z,
-        Pauli::X,
-        Pauli::I
-      ],
-      coefficient=0.5
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::Z,
-        Pauli::X,
-        Pauli::X,
-        Pauli::X,
-        Pauli::I,
-        Pauli::I
-      ],
-      coefficient=0.1
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::X,
-        Pauli::X,
-        Pauli::Y,
-        Pauli::Y,
-        Pauli::I,
-        Pauli::I
-      ],
-      coefficient=0.2
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::Y,
-        Pauli::X,
-        Pauli::Y,
-        Pauli::Z,
-        Pauli::I,
-        Pauli::I
-      ],
-      coefficient=0.8
-    },
-    PauliTerm {
-      pauli=[
-        Pauli::I,
-        Pauli::I,
-        Pauli::Y,
-        Pauli::Z,
-        Pauli::Y,
-        Pauli::I,
-        Pauli::I,
-        Pauli::I
-      ],
-      coefficient=1.0
-    }
-  ], 0.05, 400, state);
+  allocate(12, state);
+  suzuki_trotter(SparsePauliOp {
+    terms=[
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::I,
+            index=0
+          }
+        ],
+        coefficient=(-70.0615984266115) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          }
+        ],
+        coefficient=1.168865361363936 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          }
+        ],
+        coefficient=0.060577556386356 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          }
+        ],
+        coefficient=0.060577556386356 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.138994708405178) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.138994708405178) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=1.168865361363936 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.060577556386356 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.060577556386356 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.138994708405178) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.138994708405178) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          }
+        ],
+        coefficient=0.813161324486624 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.191688080068579) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.191688080068579) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.813161324486623 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.191688080068579) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.191688080068579) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          }
+        ],
+        coefficient=0.822793168060508 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.113694295467995) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.113694295467995) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.822793168060508 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.113694295467995) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.113694295467995) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.819780209159024 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.819780209159024 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.385423022220322 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.385423022220322 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.376972331290289 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.376972331290289 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.182049950409729 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.001040161015257) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.001040161015257) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.035731209151855) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.035731209151855) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.036116051494049 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.036116051494049 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.036116051494049 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.036116051494049 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.001040161015257) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.001040161015257) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.031008026364167 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.031008026364167 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.031008026364167 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.031008026364167 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.036112983506143 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.036112983506143 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.036112983506143 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.036112983506143 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.035731209151855) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.035731209151855) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.005236587185627 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.025476484847721 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.025476484847721 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.025476484847721 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.025476484847721 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.010076643457428 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.015473581100368 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.015473581100368 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.015473581100368 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.015473581100368 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          }
+        ],
+        coefficient=0.125191876897277 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.024485796710441) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.024485796710441) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          }
+        ],
+        coefficient=0.003259895744174 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          }
+        ],
+        coefficient=0.003259895744174 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.029005492860465) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.029005492860465) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.010534958028228) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.01075528119173) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.000220323163501) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.000220323163501) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.01075528119173) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.010534958028228) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=0.010354709223181 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=0.01582534195299 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=0.005470632729809 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=0.005470632729809 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=0.01582534195299 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=0.010354709223181 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.161307928391326 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.001728532360383) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.001728532360383) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.018972287887874) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.018972287887874) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.034562440167869) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.034562440167869) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          }
+        ],
+        coefficient=0.137917644638715 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.018607270167071) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.018607270167071) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.029904507669172) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.029904507669172) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.168925671002883 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.026115772277518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.026115772277518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.022072026413836) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.022072026413836) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.023843857352698) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.023843857352698) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.150736188220518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.00546079684076 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.00546079684076 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.02487258775353) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.02487258775353) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.186849171726661 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.017187006093085 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.017187006093085 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.039656325037096) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.039656325037096) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.128072355484375 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.000589136302199 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.000589136302199 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.153548840332096 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.014654249728689) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.014654249728689) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.024193926324785) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.024193926324785) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.140599348952203 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.000712771335677) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.000712771335677) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.019757260080529) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.019757260080529) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.156072930052571 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.003455209923981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.003455209923981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.017268595142477) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=0
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.017268595142477) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.161307928391326 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.001728532360383) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.001728532360383) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.018972287887874) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.018972287887874) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.004988428104557 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.008519198776818) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=(-0.010033204972591) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.008835623315268 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.034562440167869) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.034562440167869) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.019054156805047) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.019190332538449 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.125191876897277 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.024485796710441) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.024485796710441) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.003259895744174 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.003259895744174 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.029005492860465) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.029005492860465) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.010534958028228) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.01075528119173) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.000220323163501) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.000220323163501) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.01075528119173) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.010534958028228) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.010354709223181 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.01582534195299 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.005470632729809 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.005470632729809 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.01582534195299 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.010354709223181 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.168925671002883 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.026115772277518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.026115772277518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.022072026413836) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.022072026413836) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.011726209252326) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.023843857352698) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=(-0.023843857352698) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.007832481255336) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.015243386030889 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=(-0.019274479968548) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.004167981259658) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.137917644638715 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.018607270167071) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.018607270167071) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.029904507669172) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.029904507669172) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.186849171726661 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.017187006093085 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.017187006093085 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.039656325037096) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.039656325037096) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.014783737283565 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.150736188220518 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.00546079684076 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.00546079684076 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.02487258775353) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.02487258775353) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.153548840332096 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.014654249728689) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.014654249728689) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.024193926324785) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.024193926324785) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          }
+        ],
+        coefficient=0.024660965268258 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.002488664938051) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.128072355484375 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.000589136302199 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.000589136302199 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          }
+        ],
+        coefficient=0.156072930052571 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.003455209923981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.003455209923981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.017268595142477) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.017268595142477) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.140599348952203 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.000712771335677) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.000712771335677) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.019757260080529) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=6
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.019757260080529) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.158277174166043 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.022605825502569) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.022605825502569) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.01180742949996 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.01180742949996 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.01180742949996 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.01180742949996 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.007201961120307 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.007201961120307 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.007201961120307 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.007201961120307 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.007146588997479) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.017731697618187 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.017731697618187 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.017731697618187 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.017731697618187 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.022605825502569) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.022605825502569) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.038115595022731 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.038115595022731 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.038115595022731 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.038115595022731 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          }
+        ],
+        coefficient=0.137842376119681 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.017953138503535) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.017953138503535) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.03944212972062) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.03944212972062) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.008493794926849) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.007696015224157) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=0.000797779702692 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=0.000797779702692 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.007696015224157) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.008493794926849) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.149649805619641 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.040023569953414) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.040023569953414) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.010806549506056) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.010806549506056) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.150037918812519 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.041525521727187) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.041525521727187) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.157239879932826 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.047447375087191) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.047447375087191) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.125141919337981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          }
+        ],
+        coefficient=(-0.025614939987003) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          }
+        ],
+        coefficient=(-0.025614939987003) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.142873616956168 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.009482924849016) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.009482924849016) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.114593021239902 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.152708616262633 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.023306917556709) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=1
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.023306917556709) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.149649805619641 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.040023569953414) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.040023569953414) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.010806549506056) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=(-0.010806549506056) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.019599787852131 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.000581440232794 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.011105992925281 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.137842376119681 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.017953138503535) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.017953138503535) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.03944212972062) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.03944212972062) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.008493794926849) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.007696015224157) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.000797779702692 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.000797779702692 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.007696015224157) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.008493794926849) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.157239879932826 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.047447375087191) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.047447375087191) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.005921853360004 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.150037918812519 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.041525521727187) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.041525521727187) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.142873616956168 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.009482924849016) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.009482924849016) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          }
+        ],
+        coefficient=0.011903772627973 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.016132015137987) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.125141919337981 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.025614939987003) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.025614939987003) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          }
+        ],
+        coefficient=0.152708616262633 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.023306917556709) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.023306917556709) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=7
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.114593021239902 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.195731772882673 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.030327540329566) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=(-0.030327540329566) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.013982119315013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.013982119315013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=0.013982119315013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=0.013982119315013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.030327540329566) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.030327540329566) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.017158745728259 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.017158745728259 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.017158745728259 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.017158745728259 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.017239406903077 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.017239406903077 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.017239406903077 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.017239406903077 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          }
+        ],
+        coefficient=0.168269586160118 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          }
+        ],
+        coefficient=(-0.029487762648682) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          }
+        ],
+        coefficient=(-0.029487762648682) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.18225170547513 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.029046531078333) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=(-0.029046531078333) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.120107088223754 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.137265833952013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.01114293752272) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=(-0.01114293752272) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.134841336497481 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.024855626181679) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=(-0.024855626181679) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.152080743400558 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.010379490023772) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=2
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.010379490023772) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.18225170547513 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.029046531078333) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.029046531078333) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          }
+        ],
+        coefficient=(-0.000441231570349) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.168269586160118 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.029487762648682) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.029487762648682) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.137265833952013 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.01114293752272) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.01114293752272) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=(-0.014476136157907) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.120107088223754 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          }
+        ],
+        coefficient=0.152080743400558 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=(-0.010379490023772) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=(-0.010379490023772) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.134841336497481 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.024855626181679) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=8
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=(-0.024855626181679) + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.220039773343761 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.009651234083133 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.009651234083133 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          }
+        ],
+        coefficient=0.009651234083133 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          }
+        ],
+        coefficient=0.009651234083133 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.006087544308422 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.006087544308422 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.006087544308422 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.006087544308422 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          }
+        ],
+        coefficient=0.137587391610574 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.147238625693708 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.150175938709826 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=3
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.156263483018248 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.147238625693708 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.137587391610574 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          }
+        ],
+        coefficient=0.156263483018248 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=9
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.150175938709826 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.149284551210415 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.028832018326491 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.028832018326491 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Y,
+            index=11
+          }
+        ],
+        coefficient=0.028832018326491 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::X,
+            index=11
+          }
+        ],
+        coefficient=0.028832018326491 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          }
+        ],
+        coefficient=0.112753997300192 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=4
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.141586015626683 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          }
+        ],
+        coefficient=0.141586015626683 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=10
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.112753997300192 + 0j
+      },
+      SparsePauliTerm {
+        paulis=[
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=5
+          },
+          IndexedPauli {
+            pauli=Pauli::Z,
+            index=11
+          }
+        ],
+        coefficient=0.154900614778831 + 0j
+      }
+    ],
+    num_qubits=12
+  }, 1, 1, 1, state);
 }

--- a/tutorials/basic_tutorials/exponentiation/example_exponentiation.synthesis_options.json
+++ b/tutorials/basic_tutorials/exponentiation/example_exponentiation.synthesis_options.json
@@ -1,1 +1,7 @@
-{}
+{
+  "preferences": {
+    "custom_hardware_settings": {
+      "basis_gates": ["cx", "u"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Regenerated `example_exponentiation.qmod` and `example_exponentiation.synthesis_options.json` from `tutorials/basic_tutorials/exponentiation/example_exponentiation.ipynb` using `scripts/generate_qmod_from_notebooks.py`.

## Test plan
- Ran `scripts/generate_qmod_from_notebooks.py` against the notebook; generation succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)