### PR TITLE
Fix pytest warning for Collection

### DIFF
--- a/tests/notebooks/test__community_and_functions.py
+++ b/tests/notebooks/test__community_and_functions.py
@@ -32,7 +32,7 @@ def cwd(path):
 
 
 @pytest.mark.parametrize(
-    "notebook_path", filter(_should_test_notebook, iterate_notebooks())
+    "notebook_path", [nb for nb in iterate_notebooks() if _should_test_notebook(nb)]
 )
 def test_notebooks(notebook_path: str) -> None:
     with cwd(os.path.dirname(notebook_path)):

--- a/tests/qmods/test_qmods.py
+++ b/tests/qmods/test_qmods.py
@@ -22,7 +22,7 @@ def all_qmods_params() -> Iterator[ParameterSet]:
     if os.environ.get("SHOULD_TEST_ALL_FILES", "") != "true":
         iterator = filter(_should_test_file, iterator)
 
-    return (pytest.param(qmod_file, id=qmod_file.name) for qmod_file in iterator)
+    return [pytest.param(qmod_file, id=qmod_file.name) for qmod_file in iterator]
 
 
 @pytest.mark.parametrize("qmod_file", all_qmods_params())

--- a/tests/test_all_notebooks_are_tested.py
+++ b/tests/test_all_notebooks_are_tested.py
@@ -10,7 +10,9 @@ def all_test_file_names() -> list[str]:
     return [i.name for i in TESTS_FOLDER.rglob("test_*.py")]
 
 
-@pytest.mark.parametrize("notebook_name", map(os.path.basename, get_all_notebooks()))
+@pytest.mark.parametrize(
+    "notebook_name", [os.path.basename(nb) for nb in get_all_notebooks()]
+)
 def test_is_notebook_tested(notebook_name: str, all_test_file_names: list[str]):
     if not _should_skip_notebook(notebook_name):
         expected_test_name = f"test_{notebook_name[:-6]}.py"  # [:-6] removes ".ipynb"


### PR DESCRIPTION
### PR Description

wrap the map object with list, to define a collection for pytest. This shall avoid the newer version of pytest to raise a warning.

