### PR TITLE
CLS-8340: cap maxwell_2d_simulation width at 25 for the new synthesis flow

### DIFF
--- a/applications/physical_systems/maxwell_equation/maxwell_2d_simulation.ipynb
+++ b/applications/physical_systems/maxwell_equation/maxwell_2d_simulation.ipynb
@@ -872,7 +872,7 @@
     "    print(\"Synthesizing...\")\n",
     "    qprog = synthesize(\n",
     "        main_func,\n",
-    "        constraints=Constraints(max_width=1000),\n",
+    "        constraints=Constraints(max_width=25),\n",
     "        preferences=Preferences(\n",
     "            transpilation_option=TranspilationOption.NONE,\n",
     "            timeout_seconds=10 * 60,\n",


### PR DESCRIPTION
## Context

`maxwell_2d_simulation` synthesizes with `Preferences(symbolic_loops=True, transpilation_option=NONE)` and `Constraints(max_width=1000)`. Under the **new synthesis flow**, the block-encoding ancillas (LCU / `within_apply` / GQSP) are not reused the way the legacy flow reuses them, so the program comes out at ~**411 qubits** and fails the notebook test's `validate_quantum_program_size(expected_width=25)`.

## Change

Cap `max_width` at `25` in `run_simulation`. This forces the new flow to reuse qubits and fit within budget (resulting width **25**), and remains satisfiable for the legacy flow (already ~20). The algorithm and physics result are unchanged - only the qubit-allocation budget.

## Validation

Synthesized the real model in-process through the new flow (`RunNewSynthesis.ALWAYS`):
- `data.width` = 25 (was 411)
- export / metrics succeed (no QASM-version crash)

Note: this depends on the QASM-version-inference fix in Cadmium (CLS-8340) for the export path; the width cap addresses the separate size check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)