### PR TITLE
Replace float qft repeat counts with their integer floor

### DIFF
--- a/algorithms/number_theory_and_cryptography/elliptic_curves/elliptic_curve_discrete_log.qmod
+++ b/algorithms/number_theory_and_cryptography/elliptic_curves/elliptic_curve_discrete_log.qmod
@@ -36,7 +36,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[4]) {
 }
 
 qfunc qft_expanded___0(target: qbit[4]) {
-  repeat (index: 2.0) {
+  repeat (index: 2) {
     SWAP(target[index], target[3 - index]);
   }
   qft_no_swap_expanded___0(target);
@@ -565,7 +565,7 @@ qfunc qft_no_swap_expanded___1(qbv: qbit[3]) {
 }
 
 qfunc qft_expanded___1(target: qbit[3]) {
-  repeat (index: 1.5) {
+  repeat (index: 1) {
     SWAP(target[index], target[2 - index]);
   }
   qft_no_swap_expanded___1(target);

--- a/algorithms/quantum_differential_equations_solvers/discrete_poisson_solver/discrete_poisson_solver.qmod
+++ b/algorithms/quantum_differential_equations_solvers/discrete_poisson_solver/discrete_poisson_solver.qmod
@@ -14,7 +14,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[4]) {
 }
 
 qfunc qft_expanded___0(target: qbit[4]) {
-  repeat (index: 2.0) {
+  repeat (index: 2) {
     SWAP(target[index], target[3 - index]);
   }
   qft_no_swap_expanded___0(target);
@@ -307,7 +307,7 @@ qfunc qft_no_swap_expanded___1(qbv: qbit[6]) {
 }
 
 qfunc qft_expanded___1(target: qbit[6]) {
-  repeat (index: 3.0) {
+  repeat (index: 3) {
     SWAP(target[index], target[5 - index]);
   }
   qft_no_swap_expanded___1(target);

--- a/algorithms/quantum_phase_estimation/qpe_with_qubitization/qpe_for_molecule_with_qubitization.qmod
+++ b/algorithms/quantum_phase_estimation/qpe_with_qubitization/qpe_for_molecule_with_qubitization.qmod
@@ -509,7 +509,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[5]) {
 }
 
 qfunc qft_expanded___0(target: qbit[5]) {
-  repeat (index: 2.5) {
+  repeat (index: 2) {
     SWAP(target[index], target[4 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/algorithms/quantum_state_preparation/gibbs/quantum_thermal_state_preparation.qmod
+++ b/algorithms/quantum_state_preparation/gibbs/quantum_thermal_state_preparation.qmod
@@ -122,7 +122,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[4]) {
 }
 
 qfunc qft_expanded___0(target: qbit[4]) {
-  repeat (index: 2.0) {
+  repeat (index: 2) {
     SWAP(target[index], target[3 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/applications/chemistry/qpe_for_molecules/qpe_for_molecules.qmod
+++ b/applications/chemistry/qpe_for_molecules/qpe_for_molecules.qmod
@@ -834,7 +834,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[7]) {
 }
 
 qfunc qft_expanded___0(target: qbit[7]) {
-  repeat (index: 3.5) {
+  repeat (index: 3) {
     SWAP(target[index], target[6 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/applications/finance/hybrid_hhl_for_portfolio_optimization/portfolio_optimization_with_hhl.qmod
+++ b/applications/finance/hybrid_hhl_for_portfolio_optimization/portfolio_optimization_with_hhl.qmod
@@ -49,7 +49,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[4]) {
 }
 
 qfunc qft_expanded___0(target: qbit[4]) {
-  repeat (index: 2.0) {
+  repeat (index: 2) {
     SWAP(target[index], target[3 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/applications/finance/portfolio_optimization_hhl/HHL_portfolio.qmod
+++ b/applications/finance/portfolio_optimization_hhl/HHL_portfolio.qmod
@@ -313,7 +313,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[6]) {
 }
 
 qfunc qft_expanded___0(target: qbit[6]) {
-  repeat (index: 3.0) {
+  repeat (index: 3) {
     SWAP(target[index], target[5 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/applications/physical_systems/hhl_lanchester/hhl_lanchester.qmod
+++ b/applications/physical_systems/hhl_lanchester/hhl_lanchester.qmod
@@ -1118,7 +1118,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[6]) {
 }
 
 qfunc qft_expanded___0(target: qbit[6]) {
-  repeat (index: 3.0) {
+  repeat (index: 3) {
     SWAP(target[index], target[5 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/tutorials/technology_demonstrations/hhl/hhl_example.qmod
+++ b/tutorials/technology_demonstrations/hhl/hhl_example.qmod
@@ -109,7 +109,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[2]) {
 }
 
 qfunc qft_expanded___0(target: qbit[2]) {
-  repeat (index: 1.0) {
+  repeat (index: 1) {
     SWAP(target[index], target[1 - index]);
   }
   qft_no_swap_expanded___0(target);

--- a/tutorials/workshops/hhl_workshop/hhl_workshop.qmod
+++ b/tutorials/workshops/hhl_workshop/hhl_workshop.qmod
@@ -57,7 +57,7 @@ qfunc qft_no_swap_expanded___0(qbv: qbit[4]) {
 }
 
 qfunc qft_expanded___0(target: qbit[4]) {
-  repeat (index: 2.0) {
+  repeat (index: 2) {
     SWAP(target[index], target[3 - index]);
   }
   qft_no_swap_expanded___0(target);


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
