### PR TITLE
Set  optimization width in maxwell_2d_simulation

### DIFF
--- a/applications/physical_systems/maxwell_equation/maxwell_2d_simulation.ipynb
+++ b/applications/physical_systems/maxwell_equation/maxwell_2d_simulation.ipynb
@@ -872,7 +872,7 @@
     "    print(\"Synthesizing...\")\n",
     "    qprog = synthesize(\n",
     "        main_func,\n",
-    "        constraints=Constraints(max_width=1000),\n",
+    "        constraints=Constraints(optimization_parameter=\"width\"),\n",
     "        preferences=Preferences(\n",
     "            transpilation_option=TranspilationOption.NONE,\n",
     "            timeout_seconds=10 * 60,\n",


### PR DESCRIPTION
Replace the fixed `max_width` cap in the `run_simulation` helper of `maxwell_2d_simulation.ipynb` with width optimization (`Constraints(optimization_parameter="width")`), letting the synthesis engine minimize circuit width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)