### PR TITLE
Collapse create_model()+synthesize() into synthesize(main)

### DIFF
--- a/algorithms/quantum_differential_equations_solvers/discrete_poisson_solver/discrete_poisson_solver.ipynb
+++ b/algorithms/quantum_differential_equations_solvers/discrete_poisson_solver/discrete_poisson_solver.ipynb
@@ -477,8 +477,7 @@
     "    )\n",
     "\n",
     "\n",
-    "qmod = create_model(main, constraints=Constraints(max_width=18))\n",
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main, constraints=Constraints(max_width=18))\n",
     "show(qprog)"
    ]
   },

--- a/applications/finance/rainbow_options/rainbow_options_integration_method.ipynb
+++ b/applications/finance/rainbow_options/rainbow_options_integration_method.ipynb
@@ -389,9 +389,8 @@
     "\n",
     "\n",
     "MAX_WIDTH = 25\n",
-    "qmod_1 = create_model(main, constraints=Constraints(max_width=MAX_WIDTH))\n",
     "print(\"Starting synthesis\")\n",
-    "qprog_1 = synthesize(qmod_1)\n",
+    "qprog_1 = synthesize(main, constraints=Constraints(max_width=MAX_WIDTH))\n",
     "show(qprog_1)"
    ]
   },

--- a/applications/finance/rainbow_options/rainbow_options_integration_method.ipynb
+++ b/applications/finance/rainbow_options/rainbow_options_integration_method.ipynb
@@ -437,8 +437,6 @@
     }
    ],
    "source": [
-    "qmod_2 = iqae.get_model()\n",
-    "\n",
     "print(\"Starting synthesis\")\n",
     "qprog_2 = iqae.get_qprog()\n",
     "show(qprog_2)\n",

--- a/community/basic_examples/superposition/superposition.ipynb
+++ b/community/basic_examples/superposition/superposition.ipynb
@@ -51,10 +51,7 @@
     "    my_hadamard_transform(register_a)\n",
     "\n",
     "\n",
-    "model = create_model(main)\n",
-    "\n",
-    "\n",
-    "qprog = synthesize(model)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "show(qprog)"
    ]

--- a/functions/function_usage_examples/arithmetic/arithmetic_expression/arithmetic_expression_example.ipynb
+++ b/functions/function_usage_examples/arithmetic/arithmetic_expression/arithmetic_expression_example.ipynb
@@ -75,10 +75,7 @@
     "    b |= 1\n",
     "    c |= 5\n",
     "\n",
-    "    res |= (a + b + c & 15) % 8 ^ 3 & a ^ 10 == 4\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    res |= (a + b + c & 15) % 8 ^ 3 & a ^ 10 == 4"
    ]
   },
   {
@@ -99,7 +96,7 @@
     }
    ],
    "source": [
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "result = execute(qprog).result_value()\n",
     "result.parsed_counts"

--- a/functions/function_usage_examples/arithmetic/bitwise_invert/bitwise_invert_example.ipynb
+++ b/functions/function_usage_examples/arithmetic/bitwise_invert/bitwise_invert_example.ipynb
@@ -33,10 +33,7 @@
     "def main(x: Output[QNum], y: Output[QNum]) -> None:\n",
     "    x |= 6\n",
     "\n",
-    "    y |= ~x\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    y |= ~x"
    ]
   },
   {
@@ -54,7 +51,7 @@
     }
    ],
    "source": [
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "result = execute(qprog).result_value()\n",
     "print(result.counts_of_multiple_outputs([\"x\", \"y\"]))"

--- a/functions/function_usage_examples/arithmetic/modulo/modulo_example.ipynb
+++ b/functions/function_usage_examples/arithmetic/modulo/modulo_example.ipynb
@@ -59,10 +59,7 @@
     "    a ^= 4\n",
     "    b ^= 7\n",
     "\n",
-    "    res |= (a + b) % 4\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    res |= (a + b) % 4"
    ]
   },
   {
@@ -80,7 +77,7 @@
     }
    ],
    "source": [
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "result = execute(qprog).result_value()\n",
     "print(result.parsed_counts)"

--- a/functions/function_usage_examples/arithmetic/negation/negation_example.ipynb
+++ b/functions/function_usage_examples/arithmetic/negation/negation_example.ipynb
@@ -35,10 +35,7 @@
     "def main(a: Output[QNum], b: Output[QNum]) -> None:\n",
     "    allocate(3, SIGNED, 0, a)\n",
     "    hadamard_transform(a)\n",
-    "    b |= -a\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    b |= -a"
    ]
   },
   {
@@ -66,7 +63,7 @@
     }
    ],
    "source": [
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "result = execute(qprog).result_value()\n",
     "result.parsed_counts"

--- a/functions/function_usage_examples/mcx/mcx_example.ipynb
+++ b/functions/function_usage_examples/mcx/mcx_example.ipynb
@@ -61,27 +61,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "qmod = create_model(main)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "5",
    "metadata": {},
    "source": [
     "## References\n",

--- a/functions/qmod_library_reference/classiq_open_library/hadamard_transform/hadamard_transform.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/hadamard_transform/hadamard_transform.ipynb
@@ -39,10 +39,7 @@
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
     "    allocate(3, x)\n",
-    "    hadamard_transform(x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    hadamard_transform(x)"
    ]
   },
   {
@@ -52,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/classiq_open_library/linear_pauli_rotations/linear_pauli_rotations.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/linear_pauli_rotations/linear_pauli_rotations.ipynb
@@ -91,10 +91,7 @@
     "def main(x: Output[QArray[QBit]], ind: Output[QArray[QBit]]):\n",
     "    allocate(NUM_STATE_QUBITS, x)\n",
     "    allocate(len(BASES), ind)\n",
-    "    linear_pauli_rotations(BASES, SLOPES, OFFSETS, x, ind)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    linear_pauli_rotations(BASES, SLOPES, OFFSETS, x, ind)"
    ]
   },
   {
@@ -104,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/classiq_open_library/qft/qft.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/qft/qft.ipynb
@@ -46,10 +46,7 @@
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
     "    allocate(4, x)\n",
-    "    qft(x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    qft(x)"
    ]
   },
   {
@@ -59,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_bell_state.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_bell_state.ipynb
@@ -66,10 +66,7 @@
     "\n",
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
-    "    prepare_bell_state(2, x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    prepare_bell_state(2, x)"
    ]
   },
   {
@@ -79,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_exponential_state.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_exponential_state.ipynb
@@ -59,10 +59,7 @@
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
     "    allocate(5, x)\n",
-    "    prepare_exponential_state(0.1, x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    prepare_exponential_state(0.1, x)"
    ]
   },
   {
@@ -72,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_ghz_state.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/special_state_preparations/prepare_ghz_state.ipynb
@@ -59,10 +59,7 @@
     "\n",
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
-    "    prepare_ghz_state(5, x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    prepare_ghz_state(5, x)"
    ]
   },
   {
@@ -72,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   }
  ],

--- a/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/qdrift/qdrift.ipynb
+++ b/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/qdrift/qdrift.ipynb
@@ -49,8 +49,7 @@
     "    )\n",
     "\n",
     "\n",
-    "qmod = create_model(main)\n",
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   },
   {

--- a/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/suzuki_trotter/suzuki_trotter.ipynb
+++ b/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/suzuki_trotter/suzuki_trotter.ipynb
@@ -74,8 +74,7 @@
     "    )\n",
     "\n",
     "\n",
-    "qmod = create_model(main)\n",
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   },
   {

--- a/functions/qmod_library_reference/qmod_core_library/unitary/unitary.ipynb
+++ b/functions/qmod_library_reference/qmod_core_library/unitary/unitary.ipynb
@@ -46,10 +46,7 @@
     "@qfunc\n",
     "def main(x: Output[QArray[QBit]]):\n",
     "    allocate(2, x)\n",
-    "    unitary(UNITARY, x)\n",
-    "\n",
-    "\n",
-    "qmod = create_model(main)"
+    "    unitary(UNITARY, x)"
    ]
   },
   {
@@ -59,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qprog = synthesize(qmod)"
+    "qprog = synthesize(main)"
    ]
   },
   {

--- a/tests/notebooks/test_discrete_poisson_solver.py
+++ b/tests/notebooks/test_discrete_poisson_solver.py
@@ -8,8 +8,6 @@ from testbook.client import TestbookNotebookClient
 
 @wrap_testbook("discrete_poisson_solver", timeout_seconds=300)
 def test_notebook(tb: TestbookNotebookClient) -> None:
-    # test models
-    validate_quantum_model(tb.ref("qmod"))
     # test quantum programs
     validate_quantum_program_size(
         tb.ref_pydantic("qprog"),

--- a/tests/notebooks/test_entanglement.py
+++ b/tests/notebooks/test_entanglement.py
@@ -8,8 +8,6 @@ from testbook.client import TestbookNotebookClient
 
 @wrap_testbook("entanglement", timeout_seconds=60)
 def test_notebook(tb: TestbookNotebookClient) -> None:
-    # test models
-    validate_quantum_model(tb.ref("model"))
     # test quantum programs
     validate_quantum_program_size(
         tb.ref_pydantic("qprog"),

--- a/tests/notebooks/test_rainbow_options_integration_method.py
+++ b/tests/notebooks/test_rainbow_options_integration_method.py
@@ -17,9 +17,6 @@ def test_notebook(tb: TestbookNotebookClient) -> None:
     A notebook for a hybrid classical quantum neural network.
     The test verifies that the pre-trained model is indeed well trained.
     """
-    # test models
-    validate_quantum_model(tb.ref("qmod_1"))
-    validate_quantum_model(tb.ref("qmod_2"))
     # test quantum programs
     validate_quantum_program_size(
         tb.ref_pydantic("qprog_1"),

--- a/tutorials/basic_tutorials/entanglement/entanglement.ipynb
+++ b/tutorials/basic_tutorials/entanglement/entanglement.ipynb
@@ -40,10 +40,7 @@
     "    my_bell_state(registers)\n",
     "\n",
     "\n",
-    "model = create_model(main)\n",
-    "\n",
-    "\n",
-    "qprog = synthesize(model)\n",
+    "qprog = synthesize(main)\n",
     "\n",
     "show(qprog)"
    ]

--- a/tutorials/basic_tutorials/grover_graph_coloring/grover_graph_coloring.ipynb
+++ b/tutorials/basic_tutorials/grover_graph_coloring/grover_graph_coloring.ipynb
@@ -247,9 +247,8 @@
     "constraints = Constraints(\n",
     "    max_width=28,\n",
     ")\n",
-    "qmod = create_model(main, constraints=constraints)\n",
     "\n",
-    "qprog = synthesize(qmod)\n",
+    "qprog = synthesize(main, constraints=constraints)\n",
     "show(qprog)"
    ]
   },


### PR DESCRIPTION
Safe subset of the synthesis-flow migration: 19 notebooks (4 main + 1 community + 14 functions) where the collapse is unambiguous - a single create_model whose result feeds exactly one synthesize, with only constraints/preferences kwargs (moved onto synthesize). The remaining ~67 (multiple create_model calls, execution_preferences/out_file, or a reused model var) need per-notebook judgment and are deferred to a follow-up agent pass.
