### PR TITLE
Add .internal/conventions resume-kit for the notebook-uniformity effort

### DIFF
--- a/.internal/conventions/README.md
+++ b/.internal/conventions/README.md
@@ -1,0 +1,12 @@
+# Notebook convention tooling
+
+The kit for keeping the library's notebooks reading as **one entity**. Each
+convention "point" (its status and how to resume it) is tracked in `STATUS.md`.
+Run the agents/tools from the **repo root**.
+
+- **`STATUS.md`** — every convention point: done / open, on which branch, and how to resume it
+- **`agents/`** — reusable subagent definitions: heading-hierarchy, math-notation, unicode-cleanup
+- **`tools/`** — helpers used by the agents & audits: `md_replace`, `nonascii`, `math_lint`, `heading_outline`, `heading_stats`, `unicode_audit`
+- **`one_off_fixes/`** — throwaway transform/analysis scripts from past passes (kept for reference, not maintained)
+
+The read-only audit that scores every point lives at `.internal/notebook_uniformity_report.py`.

--- a/.internal/conventions/STATUS.md
+++ b/.internal/conventions/STATUS.md
@@ -1,0 +1,45 @@
+# Convention points — status & how to resume
+
+Everything below was done for the **`main` folders only** (`algorithms/`,
+`applications/`, `tutorials/` ≈ 160 notebooks). **`community/`, `functions/`,
+`benchmarking/` were deliberately not touched** — the agent-driven points can be
+re-run on them by pointing the same agent at those notebooks.
+
+To see current coverage of any point at any time:
+`python3 .internal/notebook_uniformity_report.py` (run from the repo root).
+
+| Pt   | Convention                                            | Status (main)                                                                               | Resume / extend with                                                               |
+| ---- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| A    | `show(qprog)` not `qprog.show()`                      | ✅ done + **enforced**                                                                      | pre-commit `notebook_uniformity.py`                                                |
+| 1    | `synthesize(main)` not `create_model()+synthesize()`  | 🟡 partial — 19 safe collapses done; ~67 complex left (`execution_preferences`, multi-call) | `one_off_fixes/collapse_synthesize.py` (safe subset); agent/manual for the rest    |
+| 2    | exec-result var = `result` / `result_<suffix>`        | ⛔ open                                                                                     | detector: report point 2; write a rename script/agent                              |
+| 2b   | synth-output var = `qprog` / `qprog_<suffix>`         | ⛔ open                                                                                     | detector: report point 2b                                                          |
+| 3    | `.result_value()` not `.result()[0].value`            | ✅ done + **enforced**                                                                      | `one_off_fixes/fix_result_value.py`; hook                                          |
+| 4    | title casing (Title Case)                             | ⛔ open                                                                                     | agent — needs context (QAOA/Grover proper nouns); detector: report point 4         |
+| 5    | `## References` (plural)                              | ✅ done + **enforced**                                                                      | pre-commit hook                                                                    |
+| 6    | exactly one H1 (the title)                            | ✅ done (main)                                                                              | `one_off_fixes/fix_single_h1.py` (+ `check_fences.py`, `h1_outline.py`)            |
+| 7    | heading hierarchy (levels & nesting)                  | ✅ done (main)                                                                              | **`agents/notebook-heading-hierarchy.md`** + `tools/heading_outline.py`            |
+| 8    | intro opener phrasing                                 | ⛔ open                                                                                     | agent (pick common phrasing); detector: report point 8                             |
+| 9    | section-heading vocabulary                            | ⛔ open                                                                                     | agent; detector: report point 9                                                    |
+| 12   | math: display→`$$`, unicode→LaTeX                     | ✅ done (main)                                                                              | **`agents/notebook-math-notation.md`** + `tools/md_replace.py`, `math_lint.py`     |
+| 15   | defines `@qfunc def main(...)`                        | 🔎 investigate-only                                                                         | report point 15 (comparison notebooks are documented exceptions)                   |
+| B/11 | opens with an H1 title (no code-first)                | ✅ done (main)                                                                              | folded into point 6                                                                |
+| —    | stray unicode typography (dashes/quotes/spaces→ASCII) | ✅ done (main)                                                                              | **`agents/notebook-unicode-cleanup.md`** + `tools/nonascii.py`, `unicode_audit.py` |
+| 10   | sidecar files (.qmod/.synth/.metadata)                | skipped (out of scope)                                                                      | —                                                                                  |
+
+## To extend an agent-driven point to community / functions
+
+1. `python3 tools/<detector or audit>` to list the affected notebooks in the target folder.
+2. Batch them (~6 per agent) and run the relevant `agents/*.md` definition on each,
+   editing **markdown cells only** via `tools/md_replace.py`.
+3. Verify per notebook: `tools/math_lint.py` and/or `tools/nonascii.py`, plus a
+   `jupyter nbconvert --to markdown` render (no `--execute`).
+
+## Branches / PRs (names as opened; some may already be merged)
+
+- `__result_value` — points 3, 5, A + the `notebook-uniformity` pre-commit hook
+- `__synthesize_main` — point 1 (safe subset)
+- `__single_h1` — points 6, 7, B/11
+- `__math` — point 12 (+ one malformed-`$$` fix)
+- `__unicode_cleanup` — typography cleanup (+ accent repairs in citations)
+- `__uniformity_report` — the audit tool + archived exploration scripts

--- a/.internal/conventions/agents/notebook-heading-hierarchy.md
+++ b/.internal/conventions/agents/notebook-heading-hierarchy.md
@@ -1,0 +1,109 @@
+---
+name: notebook-heading-hierarchy
+description: Review and fix the markdown heading hierarchy of ONE classiq-library notebook so it reads cleanly and consistently with the rest of the library. Use when normalizing notebook heading levels.
+tools: Bash, Read
+model: sonnet
+---
+
+You normalize the **markdown heading hierarchy** of a single Jupyter notebook in
+the classiq-library. You are given one notebook path. Work only on that notebook.
+
+## Running commands (important)
+
+Run every Bash command **bare**: no `cd`, and no `;` / `&&` chaining — a compound
+command triggers a permission prompt, a bare one does not. Your working directory
+is already correct; refer to the notebook by the **absolute path** you were given
+(or a path relative to the working directory). So: `sed -i ... /abs/path.ipynb`,
+not `cd somewhere && sed ...`.
+
+## Procedure
+
+1. Get the heading outline (fence-aware `grep ^#`, with cell indices):
+
+   ```bash
+   python3 heading_outline.py <notebook-path>
+   ```
+
+   Run it from the primary working directory; the path may be given relative to
+   that directory or to the `classiq-library/` repo — the script resolves both.
+
+2. Judge whether the hierarchy is **reasonable**. Reasonable means:
+
+   - Exactly **one H1**, at the very top — the notebook title.
+   - **No level skips** — never jump from H1 straight to H3, or H2 to H4.
+   - **Nesting reflects meaning** — a heading that is conceptually a sub-part of
+     the section above it should sit one level deeper. This includes the subtle,
+     non-mechanical case the outline alone may not reveal: **a flat run of H2s
+     where some are really sub-topics of an earlier H2** — those should become
+     H3. A jump-detector cannot see this; you must reason about the content.
+
+3. **If the outline is enough to decide, act on it. If it is not** (e.g. you
+   cannot tell whether a section is a subsection of the previous one), **Read the
+   full notebook** and judge from the actual content.
+
+4. Apply all the level changes with **one `sed -i` command**, one `-e` per
+   heading, so the whole change is readable at a glance and the `.ipynb` diff
+   touches only the changed heading lines. You change **only the number of
+   leading `#`**.
+
+   Match the opening quote + the `#`s + a **short ASCII prefix** of the heading —
+   just enough to be unique. Do **not** match the whole heading: these titles
+   often contain LaTeX (`$\mathbb{Z}$`) and `sed` would choke on `\ $ & /`.
+   Stop the match before any such character. Use `@` as the delimiter (it is not
+   `#` and rarely appears in headings):
+
+   ```bash
+   sed -i \
+     -e 's@"##### 1. Bell State@"### 1. Bell State@' \
+     -e 's@"##### 2. Entangling@"### 2. Entangling@' \
+     classiq-library/.../notebook.ipynb
+   ```
+
+   - The leading `"` anchors to a heading line (cell source lines start with a
+     quote), so prose is never matched.
+   - **Do NOT use `NotebookEdit`** (rewrites the whole cell → a huge,
+     unreviewable diff) or `nbformat`. The `Edit` tool refuses `.ipynb`; `sed` is
+     the way.
+   - Rare fallback: if the unique part of a heading unavoidably contains `\ $ & /`
+     or another heading shares your ASCII prefix, use a literal python replace
+     instead: `python3 -c "p='...';t=open(p).read();open(p,'w').write(t.replace('<old line>','<new line>'))"`.
+
+5. **Verify** by re-running `python3 .internal/conventions/tools/heading_outline.py <path>` and confirming the
+   outline now reads cleanly. **Do not run `git`** (no status/diff/add/commit) —
+   leave the edits unstaged for human review. Then report in a few lines: the
+   notebook, each change (old level → new level), and why — or that nothing
+   needed changing.
+
+**Keep it thin.** The whole job is: outline → (read only if the outline isn't
+enough) → one `sed` → outline to verify. No `git`, no extra file reads, no
+exploring other files.
+
+## Hard constraints
+
+- Only change the **level** of **existing** headings. Never add, remove, reword,
+  or reorder headings, and never touch any other content.
+- Never edit a `#` line inside a `fenced code block` — that is a code
+  comment, not a heading. `heading_outline.py` already excludes those, so only
+  act on headings it reports; your `sed` prefix includes the heading text, so it
+  won't match a bare `#`-comment anyway.
+- One notebook only. Don't wander into other files.
+
+## Corpus guidelines (soft, advisory)
+
+Derived from how each heading is used across the whole library. They describe
+**existing** headings only — never add a heading to match these. They are
+defaults, not rules: a notebook may legitimately differ, so apply common sense.
+
+When these headings exist, they are _usually_ at:
+
+- **H2 (top-level section):** `References`, `Technical Notes`, `Introduction`,
+  `Background`, `Preliminaries`, `Overview`, `Summary`, `Example` / `Examples`,
+  `Mathematical Formulation`, `Algorithm Description`, `Optimization Results`,
+  `Implementation`, `Data Definitions`, `Building the Algorithm with Classiq`,
+  `How to Build the Algorithm with Classiq`, `Solving with the Classiq platform`,
+  `Setting Up the Classiq Problem Instance`.
+- **H3 (subsection):** `Motivation`, `The model`, `Choose on which backend to
+run`, `Run Benchmark`, `Sanity Check`, `The Scoring function`.
+
+To regenerate these numbers: `python3 .internal/conventions/tools/heading_stats.py` from the primary working
+directory (it lives next to `heading_outline.py`).

--- a/.internal/conventions/agents/notebook-math-notation.md
+++ b/.internal/conventions/agents/notebook-math-notation.md
@@ -1,0 +1,94 @@
+---
+name: notebook-math-notation
+description: Normalize the math notation of ONE classiq-library notebook — display delimiters to $$, inline to $, and unicode math symbols to LaTeX — editing MARKDOWN CELLS ONLY. Use when standardizing notebook math.
+tools: Bash, Read, Write
+model: sonnet
+---
+
+You normalize **math notation** in a single Jupyter notebook. You are given one
+notebook path. **Edit markdown cells only — never code cells** (code legitimately
+contains `$` and unicode; changing it would break execution). The edit helper
+enforces this structurally, but never intend a code-cell change.
+
+## Running commands
+
+Run every Bash command **bare** (no `cd`, no `;`/`&&`). Use these absolute paths:
+
+- helper: `python3 .internal/conventions/tools/md_replace.py <nb> <spec.json>`
+- linter: `python3 .internal/conventions/tools/math_lint.py <nb>`
+- renderer: `jupyter nbconvert --to markdown --stdout <nb>`
+
+## What to normalize
+
+**1. Display delimiters → `$$…$$`.**
+
+- A **bare** `\begin{equation}` / `\begin{equation*}` block (NOT already wrapped in
+  `$$`) → replace the `\begin{equation*}` with `$$` and the matching `\end{equation*}`
+  with `$$`.
+- A **bare** `\begin{align}` / `\begin{align*}` block → wrap as
+  `$$\n\begin{aligned}…\end{aligned}\n$$` (align is invalid bare in `$$`; `aligned` is valid).
+- **Leave** `pmatrix`, `bmatrix`, `cases`, `aligned`, `split`, `array`, `matrix` — those
+  are _content_ environments that correctly live inside `$$`.
+- An `equation`/`align` wrapped in a **single** `$…$` → also normalize to `$$…$$`
+  by REPLACING the env (don't just promote the `$`).
+- **The result must always be a clean `$$ … $$`** — never `$$\begin{equation}…\end{equation}$$`.
+  Removing/replacing the `equation`/`eqnarray` env is mandatory; you only ever keep
+  _content_ envs (`aligned`, `pmatrix`, `cases`, …) inside `$$`.
+- **Leave** an `equation` env **already correctly wrapped** as `$$…$$` content only if
+  it has no `\begin{equation}` (i.e. already clean). If you see `$$\begin{equation}`,
+  that is redundant double-display — strip the env to get `$$…$$`.
+- **Keep** existing clean `$$…$$` (display) and inline `$…$` as-is. Display = math
+  standing alone on its line; inline = math inside running text. Do NOT demote a
+  standalone single-line `$$` to `$`.
+
+**2. Unicode math symbols → LaTeX.**
+Replace unicode symbols with their LaTeX commands. Placement rule:
+
+- symbol **in prose** → wrap it in `$…$`: `the angle ψ` → `the angle $\psi$`;
+  group neighbours: `φ and ψ` → `$\phi$ and $\psi$`.
+- symbol **already inside** `$…$`/`$$…$$` → just swap the char, no extra `$`.
+- symbol **inside `` `code` ``** (inline code / fenced) → **leave it** (it's a code
+  reference, not math). The helper skips code spans, so it can't be changed anyway.
+
+Mapping (common ones):
+`α \alpha · β \beta · γ \gamma · δ \delta · ε \epsilon · θ \theta · κ \kappa ·
+λ \lambda · μ \mu · ν \nu · ξ \xi · π \pi · ρ \rho · σ \sigma · τ \tau · φ \phi ·
+χ \chi · ψ \psi · ω \omega · Γ \Gamma · Δ \Delta · Θ \Theta · Λ \Lambda · Ξ \Xi ·
+Π \Pi · Σ \Sigma · Φ \Phi · Ψ \Psi · Ω \Omega · ± \pm · × \times · ÷ \div ·
+≤ \leq · ≥ \geq · ≠ \neq · ≈ \approx · ≡ \equiv · ∝ \propto · ∑ \sum · ∏ \prod ·
+∫ \int · √ \sqrt{…} · ∞ \infty · ∂ \partial · ∇ \nabla · ∈ \in · ∉ \notin ·
+⊗ \otimes · ⊕ \oplus · † \dagger · ⟨ \langle · ⟩ \rangle · · \cdot · … \dots ·
+ℏ \hbar · ℂ \mathbb{C} · ℝ \mathbb{R} · ℤ \mathbb{Z} · ℕ \mathbb{N} ·
+− \- (U+2212 minus → ASCII hyphen) · ° ^\circ · ∓ \mp · ≅ \cong · ⊆ \subseteq ·
+∀ \forall · ∃ \exists · ∅ \emptyset · ∖ \setminus`
+Arrows are context-dependent — use `\to` for "maps to / yields", `\rightarrow` /
+`\longrightarrow` for longer arrows; match what reads best.
+En/em dashes (`–`, `—`) are **prose punctuation, not math** — leave them.
+
+**Do NOT touch `\[` or `\]`** — in these notebooks they are markdown link labels
+(`[\[1\]](#ref)`) or `\\[2pt]` line-break spacing inside matrices, never display math.
+
+## Procedure
+
+1. **Read** the notebook. Inspect its markdown cells for the two issues above.
+2. Decide the exact literal replacements. **Write** them to a spec JSON at a
+   **unique path** — use `/tmp/math_spec_<notebook-stem>.json`, NOT a shared name
+   (other agents run in parallel and would clobber a shared file) — as
+   `[{"old": "...", "new": "..."}, ...]`. Make each `old` long/unique enough to match
+   exactly the intended spot(s); the helper applies a replacement to **all** non-code
+   occurrences in markdown, so include context when a bare string (like a single `ψ`)
+   would also hit places you don't mean.
+3. Apply: `python3 …/md_replace.py <nb> <your-unique-spec.json>`. If it reports NO-OP /
+   misses, re-read the exact source text and fix the `old` strings.
+4. **Verify** (both must pass):
+   - `python3 …/math_lint.py <nb>` → "OK — all clean"
+   - `jupyter nbconvert --to markdown --stdout <nb>` → converts with
+     no error (this renders the markdown without executing code).
+5. Leave edits **unstaged**; **do not run git**. Report: per change, old → new and why;
+   or "no math changes needed".
+
+## Constraints
+
+- Markdown cells only; never change math _meaning_, only notation/delimiters.
+- Minimal edits. Don't reword text, don't touch code, don't add/remove equations.
+- One notebook only.

--- a/.internal/conventions/agents/notebook-unicode-cleanup.md
+++ b/.internal/conventions/agents/notebook-unicode-cleanup.md
@@ -1,0 +1,67 @@
+---
+name: notebook-unicode-cleanup
+description: Replace stray unicode in ONE classiq-library notebook's MARKDOWN CELLS with ASCII/LaTeX equivalents (math-italic letters, smart quotes, dashes, invisible spaces), preserving references, names, and emoji. Use for the unicode-typography cleanup pass.
+tools: Bash, Read, Write
+model: sonnet
+---
+
+You replace stray unicode characters in a single notebook's **markdown cells only**
+(never code cells — they legitimately contain unicode). The edit helper enforces this.
+
+## Running commands (bare — no `cd`, no `;`/`&&`), absolute paths:
+
+- list chars: `python3 .internal/conventions/tools/nonascii.py <nb>`
+- apply: `python3 .internal/conventions/tools/md_replace.py <nb> <spec.json> [--skip=1,5]`
+- lint: `python3 .internal/conventions/tools/math_lint.py <nb>`
+- render: `jupyter nbconvert --to markdown --stdout <nb>`
+
+## Convert these (in markdown prose, outside code/references)
+
+- **Math-italic letters** (U+1D400 block, e.g. `𝐻 𝑈 𝑁 𝑂 𝐿 𝑖`) → real math in `$…$`:
+  `𝐻2`→`$H_2$`, `𝐻2𝑂`→`$H_2O$`, `𝐿𝑖𝐻`→`$LiH$`, `$𝑈(𝑁)$`→`$U(N)$`. Context-rich specs.
+- **`∣`** (U+2223 DIVIDES, e.g. `$∣01\rangle$`) → `|`.
+- **Smart quotes**: `‘ ’` (U+2018/2019) → `'`; `“ ”` (U+201C/201D) → `"`.
+- **Dashes**: em `—` (U+2014) and en `–` (U+2013) → `-` (use `-` if it reads better
+  between words).
+- **Non-breaking hyphen** `‑` (U+2011) → `-`.
+- **Invisible/odd spaces** → a normal ASCII space: no-break space (U+00A0), en quad
+  (U+2000), ideographic space (U+3000), thin/hair spaces, etc. (Only ever replace with
+  a regular space, tab, or newline — never delete a needed separator.) **But not inside
+  reference cells** — there an odd space is usually a corrupted accented name char (see
+  "References" below); skip those cells.
+
+## Leave alone
+
+- **Emoji & symbols**: `✓ ✔ ✅ ❌ 📊 🎯 ⚛️`, keycap digits like `1️⃣`, variation selectors
+  (U+FE0F), combining enclosing keycap (U+20E3).
+- **Accented letters in names** (`é è ê ä ö ø ü ñ ç č ő ı Å`, broken-accent artifacts
+  `´ ˜`) — author names in references/citations. Never ASCII-fold names.
+- **References / citations**: inside the References section and citation entries, keep
+  everything as-is — dashes, quotes, AND odd spaces. Pass those cells to `--skip=` to
+  exempt them from **all** conversions. In particular, an invisible/odd space inside a
+  citation author name is almost always a **corrupted accented letter** (e.g. `Kieferová`
+  mangled to `Kieferov‹U+2000›a`, `Gilyén` to `Gily‹U+2000›en`); normalizing it to a
+  regular space makes the name worse. Leave it and **note it in your report** for manual
+  accent repair — do not space-normalize inside references.
+- Anything inside `` `code` `` / fenced blocks (the helper skips these anyway).
+
+## Procedure
+
+1. `python3 …/nonascii.py <nb>` — see every non-ASCII char, its cell, and which cells
+   are reference-like.
+2. Decide: which chars to convert, and which cell indices to `--skip` (reference cells).
+   **Write** a spec to a **unique** path `/tmp/uni_<notebook-stem>.json` as
+   `[{"old": "...", "new": "..."}, ...]`. Char swaps are simple one-char specs; math-italic
+   need context (include the digit/parens). The helper applies a spec to **all** non-code,
+   non-skipped markdown occurrences, so use `--skip` rather than per-occurrence context
+   for reference cells.
+3. Apply: `python3 …/md_replace.py <nb> /tmp/uni_<stem>.json --skip=<ref cells>`.
+4. **Verify** (all must pass): `nonascii.py` again shows only allowed leftovers (emoji,
+   names, references); `math_lint.py` → clean; `nbconvert --to markdown` → no error.
+5. Leave edits **unstaged**; **do not run git**. Report: chars converted (with counts),
+   cells skipped, and what was deliberately left; or "no cleanup needed".
+
+## Constraints
+
+- Markdown cells only; never touch code; never ASCII-fold names; minimal edits.
+- One notebook only.

--- a/.internal/conventions/one_off_fixes/analyze_create_model.py
+++ b/.internal/conventions/one_off_fixes/analyze_create_model.py
@@ -1,0 +1,79 @@
+"""Scope point 1: categorize every create_model(...) call so we only auto-collapse
+the cases that are safe (no execution-time args), and flag the rest."""
+
+import json
+import re
+import glob
+import collections
+
+MAIN = {"algorithms", "applications", "tutorials"}
+SAFE_KWARGS = {"constraints", "preferences"}  # these move cleanly onto synthesize()
+RISKY_KWARGS = ["execution_preferences", "classical_execution_function", "out_file"]
+
+
+def balanced_close(s: str, open_idx: int) -> int:
+    depth = 0
+    for i in range(open_idx, len(s)):
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def group(path: str) -> str:
+    top = path.split("/")[0]
+    return "main" if top in MAIN else ("community" if top == "community" else "other")
+
+
+cat = collections.Counter()
+kinds_freq = collections.Counter()
+samples = collections.defaultdict(list)
+
+for p in sorted(glob.glob("**/*.ipynb", recursive=True)):
+    nb = json.load(open(p))
+    code = "\n".join(
+        "".join(c.get("source", []))
+        for c in nb.get("cells", [])
+        if c.get("cell_type") == "code"
+    )
+    if "create_model(" not in code:
+        continue
+
+    calls = []
+    for m in re.finditer(r"create_model\(", code):
+        close = balanced_close(code, m.end() - 1)
+        calls.append(code[m.end() : close])
+
+    kinds = set()
+    for inner in calls:
+        for kw in SAFE_KWARGS | set(RISKY_KWARGS):
+            if re.search(rf"\b{kw}\s*=", inner):
+                kinds.add(kw)
+    kinds_freq.update(kinds)
+
+    risky = kinds & set(RISKY_KWARGS)
+    multi = len([c for c in calls]) > 1
+    if risky:
+        c = f"RISKY (keep create_model): {sorted(risky)}"
+    elif multi:
+        c = "REVIEW: multiple create_model calls"
+    elif not kinds:
+        c = "SAFE: create_model(main), no kwargs"
+    else:
+        c = f"SAFE: only {sorted(kinds)}"
+    cat[c] += 1
+    if len(samples[c]) < 4:
+        samples[c].append(f"{group(p)}: {p}")
+
+print(f"notebooks using create_model: {sum(cat.values())}\n")
+for c, n in cat.most_common():
+    print(f"  {n:3d}  {c}")
+print("\nkwarg frequency:", dict(kinds_freq))
+print("\nsamples per category:")
+for c, ps in samples.items():
+    print(f"  [{c}]")
+    for x in ps:
+        print(f"      {x}")

--- a/.internal/conventions/one_off_fixes/check_fences.py
+++ b/.internal/conventions/one_off_fixes/check_fences.py
@@ -1,0 +1,35 @@
+"""Re-count H1s while ignoring lines inside ``` fenced code blocks ```.
+Reveals which 'headings' are actually code comments (false positives)."""
+
+import glob
+import json
+import re
+
+
+def real_headings(md: str) -> list[tuple[int, str]]:
+    out, in_fence = [], False
+    for line in md.splitlines():
+        if re.match(r"^\s*```", line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if m := re.match(r"^(#{1,6})\s+(\S.*)$", line):
+            out.append((len(m.group(1)), m.group(2).strip()))
+    return out
+
+
+for path in sorted(glob.glob("**/*.ipynb", recursive=True)):
+    nb = json.load(open(path))
+    md = "\n".join(
+        "".join(c.get("source", []))
+        for c in nb.get("cells", [])
+        if c.get("cell_type") == "markdown"
+    )
+    naive = len(re.findall(r"(?m)^#\s+\S", md))
+    real = sum(1 for lvl, _ in real_headings(md) if lvl == 1)
+    if naive != real:
+        print(f"FENCE FALSE-POSITIVE: {path}")
+        print(f"    naive H1 count={naive}  real H1 count={real}")
+    elif real > 1:
+        print(f"genuine multi-H1 ({real}): {path}")

--- a/.internal/conventions/one_off_fixes/collapse_synthesize.py
+++ b/.internal/conventions/one_off_fixes/collapse_synthesize.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Point 1 (safe subset): collapse the explicit two-step synthesis flow
+
+    qmod = create_model(main[, constraints=..., preferences=...])
+    qprog = synthesize(qmod)
+into the modern one-step form
+    qprog = synthesize(main[, constraints=..., preferences=...])
+
+A cell is transformed ONLY when every guard holds (otherwise the notebook is
+skipped and reported), so this can run over all notebooks safely:
+  - the notebook has exactly one `create_model(` call
+  - its first positional arg is `main`
+  - its only other args are `constraints=` / `preferences=`
+  - the result var is used exactly twice (the assignment + a `synthesize(var)`)
+  - that `synthesize(var)` is in the same cell
+
+Dry-run by default; pass --apply to write (json; pre-commit canonicalises later).
+"""
+
+import glob
+import json
+import re
+import sys
+
+FORBIDDEN_KWARGS = ("execution_preferences", "out_file", "classical_execution_function")
+
+
+def cell_source(cell: dict) -> str:
+    source = cell.get("source", [])
+    return "".join(source) if isinstance(source, list) else source
+
+
+def code_cells(nb: dict) -> list[dict]:
+    return [c for c in nb.get("cells", []) if c.get("cell_type") == "code"]
+
+
+def balanced_close(s: str, open_idx: int) -> int:
+    depth = 0
+    for i in range(open_idx, len(s)):
+        if s[i] == "(":
+            depth += 1
+        elif s[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def split_top_level(args_str: str) -> list[str]:
+    args, depth, current = [], 0, ""
+    for ch in args_str:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            args.append(current)
+            current = ""
+        else:
+            current += ch
+    if current.strip():
+        args.append(current)
+    return [a.strip() for a in args]
+
+
+def try_collapse(nb: dict) -> tuple[bool, str]:
+    cells = code_cells(nb)
+    full_code = "\n".join(cell_source(c) for c in cells)
+    if full_code.count("create_model(") != 1:
+        return False, "not exactly one create_model call"
+
+    cm_cell = next(c for c in cells if "create_model(" in cell_source(c))
+    cm_src = cell_source(cm_cell)
+    match = re.search(r"(\w+)\s*=\s*create_model\(", cm_src)
+    if not match:
+        return False, "create_model not a simple assignment"
+    var = match.group(1)
+    close = balanced_close(cm_src, match.end() - 1)
+    args = split_top_level(cm_src[match.end() : close])
+    if not args or args[0] != "main":
+        return False, f"first arg is not `main` ({args[:1]})"
+    kwargs = args[1:]
+    if any(forbidden in kw for kw in kwargs for forbidden in FORBIDDEN_KWARGS):
+        return False, "carries execution-time / out_file kwargs"
+    if len(re.findall(rf"\b{re.escape(var)}\b", full_code)) != 2:
+        return False, f"`{var}` is used elsewhere"
+
+    syn_pattern = rf"synthesize\(\s*{re.escape(var)}\s*\)"
+    syn_cell = next((c for c in cells if re.search(syn_pattern, cell_source(c))), None)
+    if syn_cell is None:
+        return False, f"no synthesize({var}) found"
+
+    new_call = "synthesize(main" + "".join(f", {kw}" for kw in kwargs) + ")"
+    stmt_start = cm_src.rfind("\n", 0, match.start()) + 1
+    stmt_end = close + 1
+    if stmt_end < len(cm_src) and cm_src[stmt_end] == "\n":
+        stmt_end += 1
+
+    same_cell = syn_cell is cm_cell
+    if same_cell:
+        syn = re.search(syn_pattern, cm_src)
+        edits = sorted(
+            [(stmt_start, stmt_end, ""), (syn.start(), syn.end(), new_call)],
+            reverse=True,
+        )
+        for start, end, replacement in edits:
+            cm_src = cm_src[:start] + replacement + cm_src[end:]
+        cm_cell["source"] = cm_src.splitlines(keepends=True)
+    else:
+        cm_cell["source"] = (cm_src[:stmt_start] + cm_src[stmt_end:]).splitlines(
+            keepends=True
+        )
+        syn_src = re.sub(
+            syn_pattern, lambda _m: new_call, cell_source(syn_cell), count=1
+        )
+        syn_cell["source"] = syn_src.splitlines(keepends=True)
+
+    where = "same-cell" if same_cell else "cross-cell"
+    return True, f"collapsed (var={var}, {len(kwargs)} kwarg(s), {where})"
+
+
+def main() -> None:
+    apply = "--apply" in sys.argv
+    done, skipped = [], []
+    for path in sorted(glob.glob("**/*.ipynb", recursive=True)):
+        nb = json.load(open(path))
+        if "create_model(" not in "\n".join(cell_source(c) for c in code_cells(nb)):
+            continue
+        changed, note = try_collapse(nb)
+        if changed:
+            done.append((path, note))
+            if apply:
+                with open(path, "w") as f:
+                    json.dump(nb, f, indent=1, ensure_ascii=False)
+                    f.write("\n")
+        else:
+            skipped.append((path, note))
+
+    print(
+        f"{'APPLIED' if apply else 'DRY-RUN'} — collapsed {len(done)}, skipped {len(skipped)}\n"
+    )
+    print("COLLAPSED:")
+    for path, note in done:
+        print(f"  {path}\n      {note}")
+    reasons: dict[str, int] = {}
+    for _path, note in skipped:
+        reasons[note] = reasons.get(note, 0) + 1
+    print(f"\nSKIPPED ({len(skipped)}) — left for the agent pass:")
+    for note, n in sorted(reasons.items(), key=lambda kv: -kv[1]):
+        print(f"  {n:3d}  {note}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.internal/conventions/one_off_fixes/fix_result_value.py
+++ b/.internal/conventions/one_off_fixes/fix_result_value.py
@@ -1,0 +1,37 @@
+"""Point 3: parse results via `.result_value()`, not `.result()[0].value`.
+
+Raw substring replace (the chars are not JSON-escaped inside .ipynb), so the
+notebook diff is exactly the changed line(s) — nothing else is reserialized.
+`.result()[0].value`        -> `.result_value()`
+`.result()[0].value.counts` -> `.result_value().counts`   (suffix preserved)
+"""
+
+OLD = ".result()[0].value"
+NEW = ".result_value()"
+
+MAIN = [
+    "algorithms/quantum_primitives/hadamard_test/hadamard_test.ipynb",
+    "applications/image_processing/quantum_hadamard_edge_detection/quantum_image_edge_detection.ipynb",
+    "applications/optimization/qaoa_in_qaoa/qaoa_in_qaoa.ipynb",
+    "tutorials/basic_tutorials/quantum_primitives/hadamard_test_tutorial/hadamard_test_tutorial.ipynb",
+]
+COMMUNITY = [
+    "community/paper_implementation_project/Block_encoding-ND_Laplacian/ND_Laplacian_BE.ipynb",
+    "community/paper_implementation_project/block_encoding/select_structures_BE.ipynb",
+    "community/paper_implementation_project/explicit_quantum_circuits_for_block_encoding/quantum_walks_via_efficient_blockencoding.ipynb",
+    "community/paper_implementation_project/quantum_compression_algorithm_for_symmetric_states/quantum_compression_algorithm_for_symmetric_states.ipynb",
+]
+
+
+def fix(path: str) -> int:
+    text = open(path).read()
+    count = text.count(OLD)
+    if count:
+        open(path, "w").write(text.replace(OLD, NEW))
+    return count
+
+
+for label, files in (("MAIN", MAIN), ("COMMUNITY", COMMUNITY)):
+    print(label)
+    for path in files:
+        print(f"  {fix(path):2d}  {path}")

--- a/.internal/conventions/one_off_fixes/fix_single_h1.py
+++ b/.internal/conventions/one_off_fixes/fix_single_h1.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Point 6: exactly one H1 per notebook (the title).
+
+For each target notebook: keep the first real H1 (the title) and demote every
+later real H1 to H2. "Real" = not inside a ``` fenced code block ``` (such lines
+are code comments, not headings, and must be left alone).
+
+`arithmetic_expressions` is special: its second 'H1' is an instructional
+sentence, not a section title, so we strip the `# ` to make it normal prose.
+
+Dry-run by default; pass --apply to write (json; pre-commit canonicalises later).
+"""
+
+import json
+import re
+import sys
+
+DEMOTE_FILES = [
+    "applications/CFD/heat_eq_qsvt/heat_eq_qsvt.ipynb",
+    "applications/chemistry/tensor_hypercontraction/tensor_hypercontraction.ipynb",
+    "applications/cybersecurity/whitebox_fuzzing/whitebox_fuzzing.ipynb",
+    "applications/finance/brownian_chebyshev_polynomials/brownian_chebyshev_polynomials.ipynb",
+    "applications/optimization/adapt_qaoa/adapt_qaoa.ipynb",
+    "applications/optimization/robust_posture_optimization/robust_posture_optimization.ipynb",
+    "applications/telecom/resiliency_planning/resiliency_planning_AMD.ipynb",
+    "community/Hackathons/iQuHack_2025/Challenge/classiq_iQuHack_2025_final.ipynb",
+    "community/Hackathons/iQuHack_2025/Challenge_solution/our_solution/classiq_iQuHack_2025_final_sol.ipynb",
+    "community/Hackathons/iQuHack_2025/Challenge_solution/winning_solution/classiq_iQuHack_2025_quantum_tree_sol.ipynb",
+    "community/basic_examples/hw_aware_synthesis/hw_aware_synthesis.ipynb",
+    "tutorials/workshops/algo_design_QCE_tutorial/algo_design_QCE_tutorial_part_I.ipynb",
+    "tutorials/workshops/finance_workshops/rainbow_options_workshop_bruteforce.ipynb",
+    "tutorials/workshops/oracle_workshop/oracles_workshop.ipynb",
+]
+SENTENCE_FILE = "tutorials/technology_demonstrations/arithmetic_expressions/arithmetic_expressions.ipynb"
+
+APPLY = "--apply" in sys.argv
+
+
+def lines_of(cell: dict) -> list[str]:
+    src = cell.get("source", [])
+    return src if isinstance(src, list) else src.splitlines(keepends=True)
+
+
+def transform(cell: dict, fn) -> list[str]:
+    """Apply fn(line, in_fence) -> new_line over a cell's lines, tracking fences."""
+    out, in_fence = [], False
+    for line in lines_of(cell):
+        if re.match(r"^\s*```", line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        out.append(line if in_fence else fn(line))
+    return out
+
+
+def demote_later_h1s(path: str) -> list[str]:
+    nb = json.load(open(path))
+    changes, seen_first = [], False
+
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+
+        def fn(line: str) -> str:
+            nonlocal seen_first
+            if not (m := re.match(r"^#\s+(\S.*?)\s*$", line)):
+                return line
+            if not seen_first:
+                seen_first = True
+                return line  # keep the title
+            changes.append(m.group(1)[:60])
+            return "#" + line  # H1 -> H2
+
+        cell["source"] = transform(cell, fn)
+
+    if APPLY:
+        _write(path, nb)
+    return changes
+
+
+def strip_sentence_h1(path: str) -> list[str]:
+    nb = json.load(open(path))
+    changes, seen_first = [], False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+
+        def fn(line: str) -> str:
+            nonlocal seen_first
+            if not (m := re.match(r"^#\s+(\S.*?)\s*$", line)):
+                return line
+            if not seen_first:
+                seen_first = True
+                return line
+            changes.append("(strip) " + m.group(1)[:60])
+            return re.sub(r"^#\s+", "", line)  # heading -> prose
+
+        cell["source"] = transform(cell, fn)
+    if APPLY:
+        _write(path, nb)
+    return changes
+
+
+def _write(path: str, nb: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(nb, f, indent=1, ensure_ascii=False)
+        f.write("\n")
+
+
+def main() -> None:
+    print(f"{'APPLY' if APPLY else 'DRY-RUN'}\n")
+    for path in DEMOTE_FILES:
+        changes = demote_later_h1s(path)
+        print(f"{path}\n    demoted to H2: {changes}")
+    print()
+    changes = strip_sentence_h1(SENTENCE_FILE)
+    print(f"{SENTENCE_FILE}\n    {changes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.internal/conventions/one_off_fixes/h1_outline.py
+++ b/.internal/conventions/one_off_fixes/h1_outline.py
@@ -1,0 +1,27 @@
+"""For every notebook with >1 H1, print its heading outline + the markdown cell
+index of each heading, so we can decide per-notebook how to demote extra H1s."""
+
+import glob
+import json
+import re
+
+for path in sorted(glob.glob("**/*.ipynb", recursive=True)):
+    nb = json.load(open(path))
+    headings = []  # (cell_index, level, text, is_first_line_of_cell)
+    for ci, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        src = "".join(cell.get("source", []))
+        for li, line in enumerate(src.splitlines()):
+            if m := re.match(r"^(#{1,6})\s+(\S.*)$", line):
+                headings.append((ci, len(m.group(1)), m.group(2).strip(), li == 0))
+
+    h1s = [h for h in headings if h[1] == 1]
+    if len(h1s) <= 1:
+        continue
+
+    print(f"\n{'='*78}\n{path}   ({len(h1s)} H1s)")
+    for ci, level, text, first in headings:
+        marker = "  <-- H1" if level == 1 else ""
+        pos = "" if first else " (mid-cell)"
+        print(f"   cell{ci:>3} {'#'*level} {text[:70]}{marker}{pos}")

--- a/.internal/conventions/tools/heading_outline.py
+++ b/.internal/conventions/tools/heading_outline.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Minimal pre-processing for the notebook-heading-hierarchy agent.
+
+Prints the markdown heading outline of a notebook — a fence-aware `grep ^#`.
+Lines inside ``` fenced code blocks ``` are skipped (they are code comments,
+not headings). Each heading is shown with its markdown cell index, so the agent
+can locate it to edit.
+
+Usage:  python3 heading_outline.py <path-to.ipynb>
+The path may be given relative to here or to the classiq-library/ repo.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def resolve(arg: str) -> Path:
+    for candidate in (Path(arg), Path("classiq-library") / arg):
+        if candidate.is_file():
+            return candidate
+    sys.exit(f"notebook not found: {arg}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    path = resolve(sys.argv[1])
+    nb = json.loads(path.read_text())
+
+    in_fence = False
+    found = False
+    for cell_index, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        for line in "".join(cell.get("source", [])).splitlines():
+            if re.match(r"^\s*```", line):
+                in_fence = not in_fence
+                continue
+            if not in_fence and (m := re.match(r"^(#{1,6})\s+(\S.*?)\s*$", line)):
+                found = True
+                print(f"cell {cell_index:>3}  {m.group(1)} {m.group(2)}")
+    if not found:
+        print("(no markdown headings found)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.internal/conventions/tools/heading_stats.py
+++ b/.internal/conventions/tools/heading_stats.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Corpus statistics for heading levels: for each (normalized) heading text that
+recurs across notebooks, what markdown level does it usually appear at?
+
+Produces soft guidelines for the heading-hierarchy agent — e.g. "References is
+H2 in 90/95 notebooks". It only describes EXISTING headers (never suggests
+adding any) and is advisory: a notebook may legitimately differ.
+"""
+
+import glob
+import json
+import re
+from collections import Counter, defaultdict
+
+MIN_NOTEBOOKS = 4  # only report headers common enough to generalize
+_ROOT = (
+    "classiq-library" if __import__("pathlib").Path("classiq-library").is_dir() else "."
+)
+
+
+def normalize(text: str) -> str:
+    # drop markdown emphasis/code, lowercase, keep words
+    text = re.sub(r"[`*_]", "", text)
+    text = re.sub(r"[^a-z0-9 ]", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def real_headings(nb: dict) -> list[tuple[int, str]]:
+    out, in_fence = [], False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+        for line in "".join(cell.get("source", [])).splitlines():
+            if re.match(r"^\s*```", line):
+                in_fence = not in_fence
+                continue
+            if not in_fence and (m := re.match(r"^(#{1,6})\s+(\S.*?)\s*$", line)):
+                out.append((len(m.group(1)), m.group(2)))
+    return out
+
+
+# normalized header -> {level: occurrences}, plus notebook set and a display name
+levels: dict[str, Counter] = defaultdict(Counter)
+notebooks: dict[str, set] = defaultdict(set)
+display: dict[str, Counter] = defaultdict(Counter)
+
+for path in sorted(glob.glob(_ROOT + "/**/*.ipynb", recursive=True)):
+    nb = json.load(open(path))
+    for level, text in real_headings(nb):
+        key = normalize(text)
+        if not key:
+            continue
+        levels[key][level] += 1
+        notebooks[key].add(path)
+        display[key][text.strip()] += 1
+
+rows = []
+for key, level_counts in levels.items():
+    n_nb = len(notebooks[key])
+    if n_nb < MIN_NOTEBOOKS:
+        continue
+    dominant_level, dominant_n = level_counts.most_common(1)[0]
+    total = sum(level_counts.values())
+    name = display[key].most_common(1)[0][0]
+    dist = " ".join(f"H{lvl}:{n}" for lvl, n in sorted(level_counts.items()))
+    rows.append((n_nb, name, dominant_level, 100 * dominant_n // total, dist))
+
+print(f"common headers (in >= {MIN_NOTEBOOKS} notebooks), by frequency:\n")
+print(f"  {'#nb':>3}  {'recommend':>9}  {'agree':>5}  header  [level distribution]")
+for n_nb, name, dom, pct, dist in sorted(rows, key=lambda r: -r[0]):
+    print(f"  {n_nb:>3}  {'H'+str(dom):>9}  {pct:>4}%  {name!r}  [{dist}]")

--- a/.internal/conventions/tools/math_lint.py
+++ b/.internal/conventions/tools/math_lint.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Structural math-markup linter for notebooks (MARKDOWN CELLS ONLY).
+Catches the breakage our delimiter/unicode edits could introduce — without
+executing or even rendering. Run before & after edits and compare.
+
+Checks per markdown cell:
+  - balanced $$ (even count) and balanced inline $ (even after removing $$)
+  - matched \\begin{X} / \\end{X} per environment
+  - no [$$...$$](  — a markdown link-label wrongly turned into math
+  - no leftover \\[ or \\] that became unbalanced
+"""
+import glob, json, re, sys
+
+
+def lint_cell(text: str) -> list[str]:
+    issues = []
+    dd = text.count("$$")
+    single = text.replace("$$", "").replace("\\$", "").count("$")
+    if dd % 2:
+        issues.append(f"odd $$ count ({dd})")
+    if single % 2:
+        issues.append(f"odd inline $ count ({single})")
+    for env in set(re.findall(r"\\begin\{(\w+\*?)\}", text)) | set(
+        re.findall(r"\\end\{(\w+\*?)\}", text)
+    ):
+        b, e = len(re.findall(rf"\\begin\{{{re.escape(env)}\}}", text)), len(
+            re.findall(rf"\\end\{{{re.escape(env)}\}}", text)
+        )
+        if b != e:
+            issues.append(f"\\begin/\\end mismatch for {env}: {b} vs {e}")
+    if re.search(r"\[\$\$[^]]*\$\$\]\(", text):
+        issues.append("broken link-label: [$$...$$](  — was an escaped [\\[..\\]] link")
+    return issues
+
+
+def lint(path: str) -> list[str]:
+    out = []
+    for i, c in enumerate(json.load(open(path)).get("cells", [])):
+        if c.get("cell_type") != "markdown":
+            continue
+        for msg in lint_cell("".join(c["source"])):
+            out.append(f"  cell {i}: {msg}")
+    return out
+
+
+bad = 0
+for p in sorted(sys.argv[1:]):
+    if issues := lint(p):
+        bad += 1
+        print(f"ISSUES {p}")
+        print("\n".join(issues))
+print(f"\n{'OK — all clean' if not bad else f'{bad} notebook(s) with issues'}")
+sys.exit(1 if bad else 0)

--- a/.internal/conventions/tools/md_replace.py
+++ b/.internal/conventions/tools/md_replace.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Apply literal text replacements to a notebook's MARKDOWN CELLS ONLY.
+
+An agent decides the edits, writes them to a JSON spec, and this helper applies
+them safely so code cells can never be touched:
+
+    python3 md_replace.py <notebook.ipynb> <spec.json> [--skip=1,5,9]
+
+spec.json: [{"old": "...", "new": "..."}, ...]   (applied in order)
+--skip=...: comma-separated markdown-cell indices to leave untouched (e.g. the
+            References section, so citation dashes/quotes are preserved).
+
+Guarantees:
+  - only `cell_type == "markdown"` cells are modified;
+  - within a markdown cell, text inside inline `code` spans and ``` fenced
+    blocks ``` is left untouched (so code references like `μ` are safe);
+  - skipped cell indices are never modified.
+
+Lenient: applies every spec that matches and reports any spec that matched
+nothing (so you can spot a stale `old`); writes if at least one replacement was
+made, exits 1 (no write) only if nothing matched at all.
+
+Writes JSON-aware (indent=1, ensure_ascii=False) so the diff stays minimal and
+unicode is preserved literally; pre-commit canonicalises afterward.
+"""
+import json
+import re
+import sys
+
+CODE_SPAN = re.compile(r"```.*?```|`[^`\n]*`", re.S)  # fenced or inline code
+
+
+def replace_outside_code(text: str, old: str, new: str) -> tuple[str, int]:
+    last, out, n = 0, [], 0
+    for m in CODE_SPAN.finditer(text):
+        seg = text[last : m.start()]
+        n += seg.count(old)
+        out.append(seg.replace(old, new))
+        out.append(m.group(0))  # code span verbatim
+        last = m.end()
+    tail = text[last:]
+    n += tail.count(old)
+    out.append(tail.replace(old, new))
+    return "".join(out), n
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    skip = set()
+    for a in sys.argv[1:]:
+        if a.startswith("--skip="):
+            skip = {int(x) for x in a.split("=", 1)[1].split(",") if x.strip()}
+    nb_path, spec_path = args[0], args[1]
+    specs = json.load(open(spec_path))
+    nb = json.load(open(nb_path))
+
+    counts = {i: 0 for i in range(len(specs))}
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "markdown" or idx in skip:
+            continue
+        text = "".join(cell["source"])
+        for i, s in enumerate(specs):
+            text, c = replace_outside_code(text, s["old"], s["new"])
+            counts[i] += c
+        cell["source"] = text.splitlines(keepends=True)
+
+    total = sum(counts.values())
+    misses = [specs[i]["old"] for i, c in counts.items() if c == 0]
+    if total == 0:
+        print(
+            "NO-OP (notebook unchanged) — nothing matched outside code/skipped cells."
+        )
+        return 1
+
+    with open(nb_path, "w") as f:
+        json.dump(nb, f, indent=1, ensure_ascii=False)
+        f.write("\n")
+    print(
+        f"applied: "
+        + ", ".join(f"{counts[i]}x {specs[i]['old']!r}" for i in range(len(specs)))
+    )
+    if misses:
+        print("  (note: matched nothing — " + ", ".join(repr(m) for m in misses) + ")")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.internal/conventions/tools/nonascii.py
+++ b/.internal/conventions/tools/nonascii.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""List non-ASCII characters per markdown cell of ONE notebook, to guide the
+unicode-cleanup agent. Flags reference-like cells (whose citation dashes/quotes
+should be preserved) and whether each char sits inside a code span (left alone).
+
+    python3 nonascii.py <notebook.ipynb>
+"""
+import json, re, sys, unicodedata
+from collections import Counter
+
+CODE_SPAN = re.compile(r"```.*?```|`[^`\n]*`", re.S)
+REF_HINT = re.compile(r"(?mi)^#{1,4}\s*references?\b|<a id=|\[\d+\]\(#")
+
+
+def main() -> None:
+    nb = json.load(open(sys.argv[1]))
+    any_found = False
+    for i, c in enumerate(nb.get("cells", [])):
+        if c.get("cell_type") != "markdown":
+            continue
+        text = "".join(c["source"])
+        code = [(m.start(), m.end()) for m in CODE_SPAN.finditer(text)]
+
+        def in_code(p):
+            return any(a <= p < b for a, b in code)
+
+        chars = Counter()
+        in_code_chars = Counter()
+        for p, ch in enumerate(text):
+            if ord(ch) >= 128:
+                (in_code_chars if in_code(p) else chars)[ch] += 1
+        if not chars and not in_code_chars:
+            continue
+        any_found = True
+        ref = (
+            "  <-- REFERENCE-like (preserve citation dashes/quotes; consider --skip)"
+            if REF_HINT.search(text)
+            else ""
+        )
+        print(f"cell {i}{ref}")
+        for ch, n in chars.most_common():
+            print(f"    {ch!r:>6} U+{ord(ch):04X} x{n:<3} {unicodedata.name(ch,'?')}")
+        for ch, n in in_code_chars.most_common():
+            print(
+                f"    {ch!r:>6} U+{ord(ch):04X} x{n:<3} {unicodedata.name(ch,'?')}  [in code — leave]"
+            )
+    if not any_found:
+        print("(no non-ASCII in markdown cells)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.internal/conventions/tools/unicode_audit.py
+++ b/.internal/conventions/tools/unicode_audit.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Audit non-ASCII (>0x7F) characters in notebook MARKDOWN cells.
+
+A `grep [^\\x00-\\x7f]`-style sweep, but notebook-aware: it separates
+- prose/math markdown text  (where leftover math unicode would be a miss), from
+- inline `code` / ``` fenced ``` spans (where unicode is allowed),
+and groups by character with name, counts, and an example — so we can see what
+remains and decide what's fine vs. what to also normalize.
+"""
+import glob, json, re, sys, unicodedata
+from collections import defaultdict
+
+MAIN = ("algorithms/", "applications/", "tutorials/")
+CODE_SPAN = re.compile(r"```.*?```|`[^`\n]*`", re.S)
+
+# char -> {"text": n, "code": n, "nbs": set, "ex": "..."}
+stats = defaultdict(lambda: {"text": 0, "code": 0, "nbs": set(), "ex": ""})
+
+
+def audit(path: str) -> None:
+    for c in json.load(open(path)).get("cells", []):
+        if c.get("cell_type") != "markdown":
+            continue
+        src = "".join(c["source"])
+        code_ranges = [(m.start(), m.end()) for m in CODE_SPAN.finditer(src)]
+
+        def in_code(i):
+            return any(a <= i < b for a, b in code_ranges)
+
+        for i, ch in enumerate(src):
+            if ord(ch) < 128:
+                continue
+            s = stats[ch]
+            s["code" if in_code(i) else "text"] += 1
+            s["nbs"].add(path)
+            if not s["ex"]:
+                line = src[max(0, i - 30) : i + 30].replace("\n", " ")
+                s["ex"] = line
+
+
+paths = [
+    p for p in sorted(glob.glob("**/*.ipynb", recursive=True)) if p.startswith(MAIN)
+]
+for p in paths:
+    audit(p)
+
+
+def cat(ch):
+    name = unicodedata.name(ch, "?")
+    g = unicodedata.category(ch)
+    if "GREEK" in name:
+        return "Greek letter"
+    if g.startswith("Z") or "SPACE" in name:
+        return "space/separator"
+    if ch in "‘’“”":
+        return "smart quote"
+    if ch in "–—":
+        return "dash"
+    if g == "So" or ord(ch) >= 0x1F000 or "️" == ch:
+        return "symbol/emoji"
+    if g.startswith("P"):
+        return "punctuation"
+    if g.startswith("L"):
+        return "letter (accented?)"
+    if g.startswith("S"):
+        return "math/other symbol"
+    return g
+
+
+groups = defaultdict(list)
+for ch, s in stats.items():
+    groups[cat(ch)].append((ch, s))
+
+print(f"scanned {len(paths)} main notebooks — non-ASCII in markdown cells\n")
+print(f"{'char':>6} {'U+':>7} {'text':>5} {'code':>5} {'#nb':>4}  name / example")
+for gname in sorted(
+    groups, key=lambda g: -sum(s["text"] + s["code"] for _, s in groups[g])
+):
+    tot = sum(s["text"] + s["code"] for _, s in groups[gname])
+    print(f"\n## {gname}  (total {tot})")
+    for ch, s in sorted(groups[gname], key=lambda kv: -(kv[1]["text"] + kv[1]["code"])):
+        nm = unicodedata.name(ch, "?")
+        flag = "  <-- in TEXT (not code)" if s["text"] else ""
+        print(
+            f"  {ch!r:>6} {ord(ch):>7X} {s['text']:>5} {s['code']:>5} {len(s['nbs']):>4}  {nm}{flag}"
+        )
+        if s["text"]:
+            print(f"            e.g. …{s['ex']}…")


### PR DESCRIPTION
Versioned home for the convention work so it can be resumed (esp. extending to community/functions): STATUS.md (per-point status + how-to-resume), agents/ (the 3 reusable subagent defs, paths made repo-relative), tools/ (md_replace, nonascii, math_lint, heading_outline/stats, unicode_audit), one_off_fixes/ (past transform scripts). README is the 30-second overview.
