### PR TITLE
update notebook convention  strip markdown whitespace

### DIFF
--- a/.internal/notebook_uniformity_report.py
+++ b/.internal/notebook_uniformity_report.py
@@ -64,11 +64,14 @@ class Notebook:
     markdown: str  # all markdown cells, joined
     first_cell_type: str  # "markdown" | "code" | ""
     first_cell_source: str
+    second_cell_type: str  # 2nd cell — lets a logo/image precede the H1 title
+    second_cell_source: str
 
     @classmethod
     def from_path(cls, path: Path, root: Path) -> "Notebook":
         cells = json.loads(path.read_text()).get("cells", [])
         first = cells[0] if cells else {}
+        second = cells[1] if len(cells) > 1 else {}
         rel = path.relative_to(root)
         return cls(
             rel=str(rel),
@@ -77,6 +80,8 @@ class Notebook:
             markdown=_join(cells, "markdown"),
             first_cell_type=first.get("cell_type", ""),
             first_cell_source="".join(first.get("source", [])),
+            second_cell_type=second.get("cell_type", ""),
+            second_cell_source="".join(second.get("source", [])),
         )
 
     @property
@@ -85,7 +90,13 @@ class Notebook:
 
     @property
     def opens_with_h1_title(self) -> bool:
-        return bool(re.match(r"^#\s+\S", self.first_cell_source))
+        # H1 in the first markdown cell — tolerating one leading logo/image cell
+        # (some notebooks open with a centered banner, then the H1 in cell 2).
+        if _is_h1(self.first_cell_type, self.first_cell_source):
+            return True
+        if _is_image_only(self.first_cell_type, self.first_cell_source):
+            return _is_h1(self.second_cell_type, self.second_cell_source)
+        return False
 
 
 def _join(cells: list[dict], cell_type: str) -> str:
@@ -103,6 +114,17 @@ def _group(rel: Path) -> str:
     if top == COMMUNITY_DIR:
         return "community"
     return "other"
+
+
+def _is_h1(cell_type: str, source: str) -> bool:
+    return cell_type == "markdown" and bool(re.match(r"^\s*#\s+\S", source))
+
+
+def _is_image_only(cell_type: str, source: str) -> bool:
+    # a banner/logo cell: an <img> (or html) with no prose text of its own
+    if cell_type != "markdown" or "<img" not in source:
+        return False
+    return not re.search(r"[A-Za-z0-9]", re.sub(r"<[^>]+>", "", source))
 
 
 @lru_cache

--- a/.internal/pre_commit_tools/extra_nbstripout.py
+++ b/.internal/pre_commit_tools/extra_nbstripout.py
@@ -82,6 +82,16 @@ def strip_single_notebook(notebook_path: str) -> bool:
             # keys that were intentionally kept:
             # - colab
 
+        # Normalize the opening markdown cell: a leading blank line hides the H1
+        # title (the notebook then reads as having no title), so strip the
+        # surrounding whitespace and let the title render first.
+        if nb.cells and nb.cells[0].get("cell_type") == "markdown":
+            source = nb.cells[0]["source"]
+            text = "".join(source) if isinstance(source, list) else source
+            if (stripped := text.strip()) != text:
+                nb.cells[0]["source"] = stripped.splitlines(keepends=True)
+                did_nb_change = True
+
         if did_nb_change:
             result = False
             print(f"Rewriting '{notebook_path}'")

--- a/.internal/pre_commit_tools/notebook_uniformity.py
+++ b/.internal/pre_commit_tools/notebook_uniformity.py
@@ -12,6 +12,9 @@ conforms). Add a rule by writing such a function and appending it to
 
 Currently enforced:
   - a references section heading is plural ("References", not "Reference").
+  - execution results are parsed via .result_value(), not .result()[0].value.
+  - a circuit is shown via show(qprog), not the qprog.show() method form.
+  - a notebook opens with an H1 title (optionally after a logo/banner cell).
 """
 
 import re
@@ -97,10 +100,43 @@ def show_uses_function_form(nb: nbformat.NotebookNode, auto_fix: bool) -> str:
     return f"qprog.show() should be show(qprog) ({count} occurrence(s))"
 
 
+_H1_HEADING = re.compile(r"^\s*#[ \t]+\S")
+
+
+def _is_h1_cell(cell: nbformat.NotebookNode) -> bool:
+    return cell.cell_type == "markdown" and bool(_H1_HEADING.match(cell.source))
+
+
+def _is_logo_cell(cell: nbformat.NotebookNode) -> bool:
+    """A banner/logo cell: an <img> (or other html) with no prose text of its own."""
+    if cell.cell_type != "markdown" or "<img" not in cell.source:
+        return False
+    return not re.search(r"[A-Za-z0-9]", re.sub(r"<[^>]+>", "", cell.source))
+
+
+def opens_with_h1_title(nb: nbformat.NotebookNode, auto_fix: bool) -> str:
+    """A notebook opens with an H1 title, optionally after one logo/banner cell.
+
+    Not auto-fixable (a missing title can't be invented) — reports only.
+    """
+    cells = nb.cells
+    opens_ok = bool(cells) and (
+        _is_h1_cell(cells[0])
+        or (_is_logo_cell(cells[0]) and len(cells) > 1 and _is_h1_cell(cells[1]))
+    )
+    if opens_ok:
+        return NO_ERROR
+    return (
+        "does not open with an H1 title "
+        "('# Title' in the first cell, optionally after a logo/banner cell)"
+    )
+
+
 UNIFORMITY_RULES: list[UniformityRule] = [
     references_heading_is_plural,
     results_use_result_value,
     show_uses_function_form,
+    opens_with_h1_title,
 ]
 
 

--- a/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
+++ b/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
@@ -17,7 +17,7 @@
     "$$\n",
     "Q\\equiv -  A S_0 A^{\\dagger} S_{\\psi_1},\n",
     "$$\n",
-    "thereby reducing the required number of qubits and gates of the circuit, at the expense of additional multiplicative factor polylogarithmic in the error $\\epsilon$.\n"
+    "thereby reducing the required number of qubits and gates of the circuit, at the expense of additional multiplicative factor polylogarithmic in the error $\\epsilon$."
    ]
   },
   {

--- a/algorithms/number_theory_and_cryptography/elliptic_curves/elliptic_curve_discrete_log.ipynb
+++ b/algorithms/number_theory_and_cryptography/elliptic_curves/elliptic_curve_discrete_log.ipynb
@@ -122,14 +122,7 @@
     "Elliptic curve cryptography offers the same security as RSA but with much smaller key sizes:\n",
     "- **ECC-256** provides security equivalent to **RSA-3072**\n",
     "- Smaller keys mean faster computations and less storage\n",
-    "- Critical for resource-constrained devices like smartphones and IoT sensors\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
+    "- Critical for resource-constrained devices like smartphones and IoT sensors"
    ]
   },
   {

--- a/algorithms/number_theory_and_cryptography/shor/shor.ipynb
+++ b/algorithms/number_theory_and_cryptography/shor/shor.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Shor's Factoring Algorithm\n"
+    "# Shor's Factoring Algorithm"
    ]
   },
   {

--- a/algorithms/quantum_linear_solvers/adiabatic_linear_solvers/solving_qlsp_with_aqc.ipynb
+++ b/algorithms/quantum_linear_solvers/adiabatic_linear_solvers/solving_qlsp_with_aqc.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Solving the Quantum Linear Systems Problem (QLSP) using AQC \n"
+    "# Solving the Quantum Linear Systems Problem (QLSP) using AQC"
    ]
   },
   {

--- a/algorithms/quantum_linear_solvers/vqls/vqls_with_lcu.ipynb
+++ b/algorithms/quantum_linear_solvers/vqls/vqls_with_lcu.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Variational Quantum Linear Solver (VQLS) with Linear Combination of Unitaries (LCU) Block Encoding "
+    "# Variational Quantum Linear Solver (VQLS) with Linear Combination of Unitaries (LCU) Block Encoding"
    ]
   },
   {

--- a/applications/logistics/traveling_salesman_problem/traveling_salesman_problem.ipynb
+++ b/applications/logistics/traveling_salesman_problem/traveling_salesman_problem.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Travelling Salesman Problem\n",
     "\n",
-    "The \"Travelling Salesman Problem\" [[1](#TSPWiki)] refers to finding the shortest route between cities, given their relative distances. In a more general sense, given a weighted directed graph, find the shortest route along the graph that goes through all the cities, where the weights correspond to the distance between cities. For example, in the graph below, the route along $0\\rightarrow 1\\rightarrow 2\\rightarrow 3$ yields a total distance 3, which is the shortest:\n"
+    "The \"Travelling Salesman Problem\" [[1](#TSPWiki)] refers to finding the shortest route between cities, given their relative distances. In a more general sense, given a weighted directed graph, find the shortest route along the graph that goes through all the cities, where the weights correspond to the distance between cities. For example, in the graph below, the route along $0\\rightarrow 1\\rightarrow 2\\rightarrow 3$ yields a total distance 3, which is the shortest:"
    ]
   },
   {

--- a/applications/optimization/max_clique/max_clique.ipynb
+++ b/applications/optimization/max_clique/max_clique.ipynb
@@ -5,9 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Max Clique Problem\n",
-    "\n"
+    "# Max Clique Problem"
    ]
   },
   {

--- a/applications/optimization/max_induced_k_color_subgraph/max_induced_k_color_subgraph.ipynb
+++ b/applications/optimization/max_induced_k_color_subgraph/max_induced_k_color_subgraph.ipynb
@@ -5,9 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Max Colorable Induced Subgraph Problem\n",
-    "\n"
+    "# Max Colorable Induced Subgraph Problem"
    ]
   },
   {

--- a/applications/optimization/min_graph_coloring/min_graph_coloring.ipynb
+++ b/applications/optimization/min_graph_coloring/min_graph_coloring.ipynb
@@ -5,8 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Min Graph Coloring Problem\n"
+    "# Min Graph Coloring Problem"
    ]
   },
   {

--- a/applications/optimization/rectangles_packing/rectangles_packing_grid.ipynb
+++ b/applications/optimization/rectangles_packing/rectangles_packing_grid.ipynb
@@ -43,9 +43,7 @@
     "    \n",
     "3. **_Execute and analyze results_**\n",
     "\n",
-    "    Classiq allows **execution of the Quantum Program** on any leading quantum backend - hardware or simulator.\n",
-    "\n",
-    "\n"
+    "    Classiq allows **execution of the Quantum Program** on any leading quantum backend - hardware or simulator."
    ]
   },
   {

--- a/applications/optimization/set_cover/set_cover.ipynb
+++ b/applications/optimization/set_cover/set_cover.ipynb
@@ -5,8 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Set Cover Problem\n"
+    "# Set Cover Problem"
    ]
   },
   {

--- a/applications/optimization/set_partition/set_partition.ipynb
+++ b/applications/optimization/set_partition/set_partition.ipynb
@@ -5,8 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Number Partition Problem\n"
+    "# Number Partition Problem"
    ]
   },
   {

--- a/applications/plasma/vlasov_ampere/vlasov_ampere_qiskit.ipynb
+++ b/applications/plasma/vlasov_ampere/vlasov_ampere_qiskit.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In particular, it contains: Definition of a qiskit code for the block-encoding, verification of the block-encoding functionality, and definition of QSVT step with qiskit, operating on the block-encoding unitary.\n",
     "\n",
-    "The results were obtained using Qiskit version 2.1.1. "
+    "The results were obtained using Qiskit version 2.1.1."
    ]
   },
   {

--- a/applications/plasma/vlasov_ampere/vlasov_ampere_qiskit.ipynb
+++ b/applications/plasma/vlasov_ampere/vlasov_ampere_qiskit.ipynb
@@ -5,6 +5,8 @@
    "id": "0",
    "metadata": {},
    "source": [
+    "# Quantum Simulation of Linear Kinetic Plasma Models (Qiskit)\n",
+    "\n",
     "**This notebook implements the same model that appears under [`vlasov_ampere.ipynb`](https://github.com/Classiq/classiq-library/blob/main/applications/plasma/vlasov_ampere/vlasov_ampere.ipynb) example, using qiskit. This is the code used to collect the benchmarking data in [the paper](https://arxiv.org/abs/2507.22257)**.\n",
     "\n",
     "In particular, it contains: Definition of a qiskit code for the block-encoding, verification of the block-encoding functionality, and definition of QSVT step with qiskit, operating on the block-encoding unitary.\n",

--- a/applications/telecom/resiliency_planning/resiliency_planning.ipynb
+++ b/applications/telecom/resiliency_planning/resiliency_planning.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Quantum-Based Resiliency Planning\n",
     "\n",
-    "This notebook implements the quantum-based resiliency planning using QAOA.\n"
+    "This notebook implements the quantum-based resiliency planning using QAOA."
    ]
   },
   {

--- a/community/Hackathons/QInnovision_2025/advection_equation/advection_equation_2nd_place_submission.ipynb
+++ b/community/Hackathons/QInnovision_2025/advection_equation/advection_equation_2nd_place_submission.ipynb
@@ -5,8 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\n",
-    "# Solving the Advection Equation\n"
+    "# Solving the Advection Equation"
    ]
   },
   {

--- a/community/Hackathons/QInnovision_2025/advection_equation/advection_equation_winning_submission.ipynb
+++ b/community/Hackathons/QInnovision_2025/advection_equation/advection_equation_winning_submission.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "\\# Solving the Advection Equation (Hamiltonian Simulation)"
+    "# Solving the Advection Equation (Hamiltonian Simulation)"
    ]
   },
   {

--- a/community/basic_examples/hw_aware_synthesis/hw_aware_synthesis.ipynb
+++ b/community/basic_examples/hw_aware_synthesis/hw_aware_synthesis.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "<!--The two different fictitious hardware created here demonstrates how to insert your own custom-designed machine. For comparison, we create two types of hardware with `cx, u` basis gates. The difference between them manifests in the connectivity map: one has grid connectivity while the other has star connectivity.-->\n",
     "\n",
-    "<!--The two fictitious hardware created are using two different simulators, Classiq's Simulator and IonQ's Simulator. We will compare the depth of the circuit and we will optimise the number of cnot gates as they cause more errors and are very expensive. At the end of the tutorial we will also see the depth of both the circuits created.-->\n"
+    "<!--The two fictitious hardware created are using two different simulators, Classiq's Simulator and IonQ's Simulator. We will compare the depth of the circuit and we will optimise the number of cnot gates as they cause more errors and are very expensive. At the end of the tutorial we will also see the depth of both the circuits created.-->"
    ]
   },
   {

--- a/community/basic_examples/superposition/superposition.ipynb
+++ b/community/basic_examples/superposition/superposition.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Quantum Superposition with Classiq\n",
     "\n",
-    "Superposition is a key concept in all quantum algorithms. In this tutorial, we show how to create an equal superposition on 3 qubits, using the Hadamard transform. "
+    "Superposition is a key concept in all quantum algorithms. In this tutorial, we show how to create an equal superposition on 3 qubits, using the Hadamard transform."
    ]
   },
   {

--- a/community/basic_examples/vqe/vqe.ipynb
+++ b/community/basic_examples/vqe/vqe.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "We are going to create a VQE algorithm to estimate the minimum energy(eigenvalue) of the following Hamiltonian\n",
     "$$Z+0.1\\cdot X$$ \n",
-    "where $Z$ and $X$ are Pauli Operators and the ansatz we take is a single qubit $RY$ gate "
+    "where $Z$ and $X$ are Pauli Operators and the ansatz we take is a single qubit $RY$ gate"
    ]
   },
   {

--- a/community/paper_implementation_project/quantum_algo_for_solving_linear_differential_equations/harmonic_oscillator.ipynb
+++ b/community/paper_implementation_project/quantum_algo_for_solving_linear_differential_equations/harmonic_oscillator.ipynb
@@ -32,7 +32,7 @@
     "x(t) \\approx \\sum_{m=0}^{k} \\frac{(M t)^m}{m!} x(0) + \\sum_{n=1}^{k} \\frac{M^{n-1} t^n}{n!} b, \n",
     "$$\n",
     "\n",
-    "where $k$ is the approximation order.\n"
+    "where $k$ is the approximation order."
    ]
   },
   {

--- a/functions/qmod_library_reference/classiq_open_library/hadamard_transform/hadamard_transform.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/hadamard_transform/hadamard_transform.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "- `target`: `QArray[QBit]`\n",
     "\n",
-    "The `target` quantum argument is the quantum state on which we apply the Hadamard Transform.\n"
+    "The `target` quantum argument is the quantum state on which we apply the Hadamard Transform."
    ]
   },
   {

--- a/functions/qmod_library_reference/classiq_open_library/qct_qst/qct_qst.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/qct_qst/qct_qst.ipynb
@@ -44,7 +44,7 @@
     "\\qquad j,k = 0\\dots,N-1 \n",
     "$$\n",
     "\n",
-    "The open library includes four functions, following the implementation in Ref. [[1](#QCST)]: "
+    "The open library includes four functions, following the implementation in Ref. [[1](#QCST)]:"
    ]
   },
   {

--- a/functions/qmod_library_reference/classiq_open_library/variational_data_encoding/variational_data_encoding.ipynb
+++ b/functions/qmod_library_reference/classiq_open_library/variational_data_encoding/variational_data_encoding.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Variational Data Encoding\n",
     "\n",
-    "Encoding classical data on quantum states is an important subroutine in variational quantum circuits, such as Quantum Singular Vector Machine (QSVM) and Quantum Neural Networks (QNN). "
+    "Encoding classical data on quantum states is an important subroutine in variational quantum circuits, such as Quantum Singular Vector Machine (QSVM) and Quantum Neural Networks (QNN)."
    ]
   },
   {

--- a/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/suzuki_trotter/suzuki_trotter.ipynb
+++ b/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/suzuki_trotter/suzuki_trotter.ipynb
@@ -22,7 +22,7 @@
     "* For a given order, repetitions refers to \n",
     "$$\n",
     "ST^{(o,r)}(H,t) = [ST^{(o)}(H,t/r)]^r.\n",
-    "$$ \n"
+    "$$"
    ]
   },
   {

--- a/tutorials/advanced_tutorials/discrete_quantum_walk_2d/discrete_time_quantum_walk.ipynb
+++ b/tutorials/advanced_tutorials/discrete_quantum_walk_2d/discrete_time_quantum_walk.ipynb
@@ -15,8 +15,7 @@
     "\n",
     "Unlike classical random walks, quantum walks exhibit dramatically different behavior due to interference and unitarity. For instance, the probability distribution does not take a Gaussian form; instead, it spreads ballistically, leading to an $O(t)$ dispersion rather than the classical $O(\\sqrt{t})$. These properties form the foundation for the speedups observed in quantum-walk-based algorithms.\n",
     "\n",
-    "Quantum walks have a wide range of applications, including search algorithms, Hamiltonian simulation, quantum Markov chains, and quantum machine learning. In particular, Szegedy's quantum walk provides a general framework for quantizing classical Markov chains into unitary operators, enabling powerful algorithmic constructions across diverse domains.\n",
-    "\n"
+    "Quantum walks have a wide range of applications, including search algorithms, Hamiltonian simulation, quantum Markov chains, and quantum machine learning. In particular, Szegedy's quantum walk provides a general framework for quantizing classical Markov chains into unitary operators, enabling powerful algorithmic constructions across diverse domains."
    ]
   },
   {

--- a/tutorials/basic_tutorials/optimization/learning_optimization.ipynb
+++ b/tutorials/basic_tutorials/optimization/learning_optimization.ipynb
@@ -27,8 +27,7 @@
     "\n",
     "You need to know almost nothing regarding quantum algorithms, besides one thing. There are two common algorithms used for optimization problems (as well as chemistry): QAOA and VQE. Both are very similar, where QAOA could be seen as a specific type of VQE.\n",
     "\n",
-    "For this problem, use the QAOA algorithm. The algorithm has a mandatory parameter that you need to choose, as explained below.\n",
-    "\n"
+    "For this problem, use the QAOA algorithm. The algorithm has a mandatory parameter that you need to choose, as explained below."
    ]
   },
   {

--- a/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
+++ b/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Quantum Monte Carlo Integration to Estimate Pi Using Quantum Amplitude Estimation "
+    "# Quantum Monte Carlo Integration to Estimate Pi Using Quantum Amplitude Estimation"
    ]
   },
   {

--- a/tutorials/workshops/combinatorial_workshop/combinatorial_qmod_workshop_for_maxcut.ipynb
+++ b/tutorials/workshops/combinatorial_workshop/combinatorial_qmod_workshop_for_maxcut.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "## Combinatorial Optimization Workshop using the Qmod quantum types - part 1"
+    "# Combinatorial Optimization Workshop using the Qmod quantum types - part 1"
    ]
   },
   {


### PR DESCRIPTION
- Strip whitespace around the opening markdown cell so the H1 title renders
- Accept a leading logo cell before the H1 in the uniformity report
- Fix three notebook titles: unescape heading, H2 to H1, add missing H1
- Enforce opening H1 title in notebook-uniformity hook
