### PR TITLE
Migrate quantum_autoencoder validation cells to new execution API (D5)

### DIFF
--- a/algorithms/QML/quantum_autoencoder/quantum_autoencoder.ipynb
+++ b/algorithms/QML/quantum_autoencoder/quantum_autoencoder.ipynb
@@ -659,13 +659,7 @@
    "id": "40",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "trained_w = encoder_train_network.qlayer.weight.tolist()\n",
-    "input_data = train_dataset.data.tolist()\n",
-    "batch_data = [{\"w\": trained_w, \"input_data\": data} for data in input_data]\n",
-    "with ExecutionSession(qprog_validator) as es:\n",
-    "    results_validator = es.batch_sample(batch_data)"
-   ]
+   "source": "trained_w = encoder_train_network.qlayer.weight.tolist()\ninput_data = train_dataset.data.tolist()\nbatch_data = [{\"w\": trained_w, \"input_data\": data} for data in input_data]\nresults_validator = sample(qprog_validator, parameters=batch_data)"
   },
   {
    "cell_type": "markdown",
@@ -691,12 +685,7 @@
      ]
     }
    ],
-   "source": [
-    "for data, res in zip(input_data, results_validator):\n",
-    "    df = res.dataframe\n",
-    "    output = df.loc[df[\"probability\"].idxmax(), \"decoded\"]\n",
-    "    print(\"input =\", data, \",   output =\", output)"
-   ]
+   "source": "for data, res in zip(input_data, results_validator):\n    df = res\n    output = df.loc[df[\"probability\"].idxmax(), \"decoded\"]\n    print(\"input =\", data, \",   output =\", output)"
   },
   {
    "cell_type": "markdown",
@@ -720,22 +709,7 @@
    "id": "45",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import random\n",
-    "\n",
-    "input_anomaly_data = [\n",
-    "    [0, 0, 1, 1],\n",
-    "    [0, 0, 0, 1],\n",
-    "    [0, 1, 1, 1],\n",
-    "    [1, 0, 1, 0],\n",
-    "    [1, 1, 1, 1],\n",
-    "]\n",
-    "random.shuffle(input_anomaly_data)\n",
-    "\n",
-    "batch_data = [{\"w\": trained_w, \"input_data\": data} for data in input_anomaly_data]\n",
-    "with ExecutionSession(qprog_ae_network) as es:\n",
-    "    results_anomaly = es.batch_sample(batch_data)"
-   ]
+   "source": "import random\n\ninput_anomaly_data = [\n    [0, 0, 1, 1],\n    [0, 0, 0, 1],\n    [0, 1, 1, 1],\n    [1, 0, 1, 0],\n    [1, 1, 1, 1],\n]\nrandom.shuffle(input_anomaly_data)\n\nbatch_data = [{\"w\": trained_w, \"input_data\": data} for data in input_anomaly_data]\nresults_anomaly = sample(qprog_ae_network, parameters=batch_data)"
   },
   {
    "cell_type": "markdown",
@@ -763,17 +737,7 @@
      ]
     }
    ],
-   "source": [
-    "tolerance = 1e-2\n",
-    "for data, res in zip(input_anomaly_data, results_anomaly):\n",
-    "    # The probabiliy of the test qubit\n",
-    "    alpha_sqaured = res.counts_of_output(\"test\").get(\"0\", 0) / num_shots\n",
-    "    output = 1 - alpha_sqaured\n",
-    "    if abs(output) > tolerance:\n",
-    "        print(f\"input= {data},   loss= {output} ----> ANOMALY DETECTED\")\n",
-    "    else:\n",
-    "        print(f\"input= {data},   loss= {output}\")"
-   ]
+   "source": "tolerance = 1e-2\nfor data, res in zip(input_anomaly_data, results_anomaly):\n    # The probabiliy of the test qubit\n    alpha_sqaured = res.loc[res[\"test\"] == 0, \"counts\"].sum() / num_shots\n    output = 1 - alpha_sqaured\n    if abs(output) > tolerance:\n        print(f\"input= {data},   loss= {output} ----> ANOMALY DETECTED\")\n    else:\n        print(f\"input= {data},   loss= {output}\")"
   },
   {
    "cell_type": "markdown",

--- a/tests/notebooks/test_quantum_autoencoder.py
+++ b/tests/notebooks/test_quantum_autoencoder.py
@@ -32,6 +32,6 @@ def test_notebook(tb: TestbookNotebookClient) -> None:
 
     # test notebook content
     for data, res in zip(tb.ref("input_data"), tb.ref_pydantic("results_validator")):
-        df = res.dataframe
+        df = res
         output = df.loc[df["probability"].idxmax(), "decoded"]
         assert data == output, "autoencoder failed to encode"


### PR DESCRIPTION
## Section: Blocked on D5 — execute_qnn / Torch QLayer

Migrates the mechanical parts of the D5 section per the [migration checklist](https://classiq.atlassian.net/wiki/spaces/TEAM/pages/1954349069).

Per decision **D5** — *execute_qnn stays as-is; only replace a user-defined execute function in a QLayer if it does NOT use execute_qnn* — the two QNN training notebooks need no change, and only `quantum_autoencoder`'s two non-training validation cells are migrated.

### Changes
`algorithms/QML/quantum_autoencoder/quantum_autoencoder.ipynb` — the two `ExecutionSession.batch_sample` **validation** cells → `sample(qprog, parameters=[...])`, consuming the returned DataFrames directly. The `execute_qnn`-based `QLayer` training path is left untouched.

- Cell 40: `with ExecutionSession(qprog_validator) as es: es.batch_sample(batch_data)` → `sample(qprog_validator, parameters=batch_data)`
- Cell 42: `df = res.dataframe` → `df = res`
- Cell 45: `with ExecutionSession(qprog_ae_network) as es: es.batch_sample(batch_data)` → `sample(qprog_ae_network, parameters=batch_data)`
- Cell 47: `res.counts_of_output("test").get("0", 0)` → `res.loc[res["test"] == 0, "counts"].sum()`

### No change needed (per D5)
- `algorithms/QML/hybrid_qnn/hybrid_qnn_for_subset_majority.ipynb` — `execute_qnn` passed directly to `QLayer`; no standalone execution.
- `algorithms/QML/qgan/qgan_bars_and_strips.ipynb` — same.

### Verification
- Content-aligned diff: only cells 40/42/45/47 changed; outputs + execution_counts preserved; cell count unchanged.
- Simulator run confirming `sample(parameters=[...])` returns a list of DataFrames; the per-variable `test` column is `int64` (so `== 0` is correct); `df.loc[df["probability"].idxmax(), "<var>"]` works.
- Omitting `num_shots` preserves the original default-shots behavior (qprogs synthesized without execution prefs; old `batch_sample` used no shots arg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)