### PR TITLE
Migrate D4 (IQAE) section: quantum_counting & qmci_pi_estimation non-IQAE cells

### DIFF
--- a/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
+++ b/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
@@ -271,9 +271,7 @@
    "id": "17",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "result = execute(qprog_qpe).result_value()"
-   ]
+   "source": "result = sample(qprog_qpe)"
   },
   {
    "cell_type": "markdown",
@@ -307,17 +305,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "phases_counts = dict(\n",
-    "    (sampled_state.state[\"phase_reg\"], sampled_state.shots)\n",
-    "    for sampled_state in result.parsed_counts\n",
-    ")\n",
-    "plt.bar(phases_counts.keys(), phases_counts.values(), width=0.1)\n",
-    "plt.xticks(rotation=90)\n",
-    "print(\"phase with max probability: \", max(phases_counts, key=phases_counts.get))"
-   ]
+   "source": "import matplotlib.pyplot as plt\n\nphases_counts = dict(zip(result[\"phase_reg\"], result[\"counts\"]))\nplt.bar(phases_counts.keys(), phases_counts.values(), width=0.1)\nplt.xticks(rotation=90)\nprint(\"phase with max probability: \", max(phases_counts, key=phases_counts.get))"
   },
   {
    "cell_type": "markdown",

--- a/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
+++ b/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
@@ -326,13 +326,7 @@
    "id": "11",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "result = execute(qprog).result_value()\n",
-    "phases_counts = dict(\n",
-    "    (sampled_state.state[\"phase_reg\"], sampled_state.shots)\n",
-    "    for sampled_state in result.parsed_counts\n",
-    ")"
-   ]
+   "source": "result = sample(qprog)\nphases_counts = dict(zip(result[\"phase_reg\"], result[\"counts\"]))"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Migrates the independently-migratable execution cells in the **"Blocked on D4 — IQAE"** section of the [New Execution API Migration checklist](https://classiq.atlassian.net/wiki/spaces/TEAM/pages/1954349069).

## Decision applied
D4 resolved as **"IQAE stays as is."** All `IQAE(...)` construction, `.get_qprog()`, `.run(...)` (including `.run(execution_preferences=ExecutionPreferences(...))`), and IQAE result-parsing cells are left untouched. Only the independent, non-IQAE execution calls were migrated.

## Changes
Both notebooks use the same behavior-preserving swap on a single QPE-style `phase_reg` QNum output:
- `execute(qprog).result_value()` → `sample(qprog)`
- `dict((s.state["phase_reg"], s.shots) for s in result.parsed_counts)` → `dict(zip(result["phase_reg"], result["counts"]))`

| Notebook | Change |
|---|---|
| `quantum_counting.ipynb` | QPE branch (cells 17, 19); IQAE branch untouched |
| `qmci_pi_estimation.ipynb` | direct-sampling cell (11); IQAE convergence loop untouched |

No backend passed (matches old default simulator); no `transpilation_option` added; no imports added.

## Section notebooks left unchanged (no non-IQAE execution)
- `rainbow_options_workshop_bruteforce.ipynb` — sole execution is `iqae.run(execution_preferences=...)`, which IQAE still accepts.
- `quantum_autocallable_option_pricing.ipynb` — `iqae.run()` is commented out, result hardcoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)