### PR TITLE
CLS-8612: Move res allocation in Qmod tutorial part 2

### DIFF
--- a/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
@@ -798,18 +798,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "37",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quantum program link: https://platform.classiq.io/circuit/3EJD8i2H6PuZsGS4qNnYL87Ak7M\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Solution to Exercise 10:\n",
     "from classiq import *\n",
@@ -817,12 +809,12 @@
     "\n",
     "@qfunc\n",
     "def main(x: Output[QNum[3, UNSIGNED, 3]], res: Output[QNum[5, UNSIGNED, 3]]) -> None:\n",
-    "    allocate(5, res)\n",
     "    allocate(3, x)\n",
     "    hadamard_transform(x)\n",
     "\n",
     "    aux = QBit()\n",
     "    aux |= x < 0.5\n",
+    "    allocate(5, res)\n",
     "    control(\n",
     "        aux,\n",
     "        stmt_block=lambda: inplace_xor(2.0 * x + 1.0, res),\n",
@@ -852,18 +844,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "40",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Quantum program link: https://platform.classiq.io/circuit/3EJD9el3okie9bOkxDBmFj9N0QA\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Solution to Exercise 10b:\n",
     "from classiq import *\n",
@@ -871,12 +855,12 @@
     "\n",
     "@qfunc\n",
     "def main(x: Output[QNum[3, UNSIGNED, 3]], res: Output[QNum[5, UNSIGNED, 3]]) -> None:\n",
-    "    allocate(5, res)\n",
     "    allocate(3, x)\n",
     "    hadamard_transform(x)\n",
     "\n",
     "    aux = QBit()\n",
     "    aux |= x < 0.5\n",
+    "    allocate(5, res)\n",
     "    control(\n",
     "        aux,\n",
     "        stmt_block=lambda: inplace_add(2.0 * x + 1.0, res),\n",


### PR DESCRIPTION
### Ticket
[CLS-8612] Move allocation in Qmod tutorial part 2 (#13)

### What
In `Qmod_tutorial_part2.ipynb`, the Exercise 10a and 10b solutions allocate `res` (`allocate(5, res)`) at the very start of `main`. This reserves those 5 qubits throughout the `aux |= x < 0.5` comparison, inflating the circuit width in the new synthesis flow.

The allocation is moved to just before the `control` block (right after `aux |= x < 0.5`). Since `res` is only first used inside the `control` block, this is semantically equivalent, but it now lets the synthesizer reuse `res`'s qubits as auxiliaries for the comparison.

The old synthesis flow performed topological ordering and moved this allocation automatically; the new flow does not, so the notebook does it explicitly.

### DoD
- width = 11 in the new flow ✅ (allocation moved so res qubits are freed for the comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)