### PR TITLE
Fix gradient_estimation page title (first heading was "Initialization")

### DIFF
--- a/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
+++ b/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
@@ -5,26 +5,6 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Initialization"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from gradient_estimation_helpers import *\n",
-    "\n",
-    "from classiq.execution.functions.util._logging import _logger"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2",
-   "metadata": {},
-   "source": [
     "# Fast Quantum Algorithm for Numerical Gradient Estimation\n",
     "> Given a scalar function of $d$ dimensions, $f(x_1, \\ldots, x_d)$, computing its gradient at a specific point is often essential.\n",
     ">\n",
@@ -54,10 +34,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "1",
    "metadata": {},
    "source": [
     "# Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## Initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gradient_estimation_helpers import *\n",
+    "\n",
+    "from classiq.execution.functions.util._logging import _logger"
    ]
   },
   {


### PR DESCRIPTION
## Problem
In the docs, the Gradient Estimation page rendered with the title/sidebar label **"Initialization"** instead of its real title. The docs pipeline derives a page's title from the notebook's **first `#` heading**, and this notebook opened with `# Initialization` (a setup/imports cell) before the real title.

## Fix
Move the Initialization setup, the `# Initialization` heading plus its two import lines, to sit under the Introduction section as `## Initialization` (one tier below `# Introduction`). The notebook now opens with `# Fast Quantum Algorithm for Numerical Gradient Estimation`, so the generated page title is correct.

Code execution order is unchanged: the imports remain the first code cell to run (only markdown title cells preceded them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)