### PR TITLE
Give the two Algo Design QCE workshop notebooks distinct titles

### DIFF
--- a/tutorials/workshops/algo_design_QCE_tutorial/algo_design_QCE_tutorial_part_I.ipynb
+++ b/tutorials/workshops/algo_design_QCE_tutorial/algo_design_QCE_tutorial_part_I.ipynb
@@ -5,8 +5,8 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# High-level Algorithm Design with Qmod\n",
-    "## Workshop Part I - Language Concepts"
+    "# High-level Algorithm Design with Qmod Part I\n",
+    "## Language Concepts"
    ]
   },
   {

--- a/tutorials/workshops/algo_design_QCE_tutorial/algo_design_QCE_tutorial_part_II.ipynb
+++ b/tutorials/workshops/algo_design_QCE_tutorial/algo_design_QCE_tutorial_part_II.ipynb
@@ -5,8 +5,8 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# High-level Algorithm Design with Qmod\n",
-    "## Workshop Part II - QAOA Knapsack"
+    "# High-level Algorithm Design with Qmod Part II\n",
+    "## QAOA Knapsack"
    ]
   },
   {


### PR DESCRIPTION
## Problem

The two workshop notebooks under `tutorials/workshops/algo_design_QCE_tutorial/` both used the identical H1 heading `# High-level Algorithm Design with Qmod`. Since the docs generator derives each page's title from the first H1, both parts rendered with the same title in the sidebar and Tutorials Overview, making them indistinguishable.

## Change

- **Part I**: H1 → `High-level Algorithm Design with Qmod Part I`, H2 → `Language Concepts`
- **Part II**: H1 → `High-level Algorithm Design with Qmod Part II`, H2 → `QAOA Knapsack`

Only the first markdown cell of each notebook changed; no code or outputs were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)