### PR TITLE
Fix stray H1 headings in gradient_estimation (single-H1 compliance)

### DIFF
--- a/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
+++ b/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
@@ -37,7 +37,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "# Introduction"
+    "## Introduction"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "# Implementation"
+    "## Implementation"
    ]
   },
   {
@@ -1558,7 +1558,7 @@
    "id": "42",
    "metadata": {},
    "source": [
-    "# Performance Analysis"
+    "## Performance Analysis"
    ]
   },
   {
@@ -1773,7 +1773,7 @@
    "id": "47",
    "metadata": {},
    "source": [
-    "# Multi-Dimensional Examples"
+    "## Multi-Dimensional Examples"
    ]
   },
   {
@@ -1839,7 +1839,7 @@
    "id": "50",
    "metadata": {},
    "source": [
-    "# Summary and Discussion\n",
+    "## Summary and Discussion\n",
     "\n",
     "This notebook demonstrated Jordan's quantum gradient estimation algorithm, which estimates $\\nabla f$ at the origin using a **single query** to $f$, compared to the classical lower bound of $d+1$ queries.\n",
     "\n",
@@ -1877,7 +1877,7 @@
    "id": "51",
    "metadata": {},
    "source": [
-    "# Appendices\n",
+    "## Appendices\n",
     "## Appendix 1 - Phase Kickback\n",
     "\n",
     "We start with the state $|\\delta\\rangle|0\\rangle$ where $|\\delta\\rangle$ is a superposition created by the Hadamard gate for all the coordinates, hence:\n",
@@ -1920,7 +1920,7 @@
    "id": "52",
    "metadata": {},
    "source": [
-    "# References"
+    "## References"
    ]
   },
   {


### PR DESCRIPTION
`gradient_estimation.ipynb` predates the single-H1 pre-commit enforcement (#1642), so its
section headings (`# Introduction`, `# Implementation`, … `# References`) are still H1.

Because `Lint.yml` runs `pre-commit --all-files`, the single-H1 hook auto-demotes them on
**every** PR → non-empty diff → Lint fails repo-wide (main doesn't run Lint on push, so it
stayed latent). This demotes the 7 stray H1s to `##` — exactly the hook's own fix.
Markdown-only; no code or output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
