### PR TITLE
Fix gradient_estimation heading hierarchy (single H1 title)

### DIFF
--- a/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
+++ b/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
@@ -37,7 +37,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "# Introduction"
+    "## Introduction"
    ]
   },
   {
@@ -45,7 +45,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "## Initialization"
+    "### Initialization"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## Simplified explanation of the algorithm\n",
+    "### Simplified explanation of the algorithm\n",
     "The algorithm has two main steps:\n",
     "1. Encode the function into the phases of the coordinate register's superposition\n",
     "2. Apply an inverse QFT to transform the coordinate register directly into the measurable gradient state\n",
@@ -105,7 +105,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Full explanation of the algorithm\n",
+    "### Full explanation of the algorithm\n",
     "The simplified explanation captures the key idea but omits two important details: handling negative values and fractional representation.\n",
     "\n",
     "When estimating the gradient, we analyze an interval $l$ around the origin.\n",
@@ -136,14 +136,14 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "## Parameter Selection\n",
+    "### Parameter Selection\n",
     "We need to select appropriate values for $l$, $m$, and $N$. We use the following notation: \n",
     "* $\\nabla f_{\\text{max}}$ — bound on the gradient magnitude: $|\\nabla f|<\\nabla f_{\\text{max}}$\n",
     "* $\\epsilon$ — desired accuracy: $|\\nabla f_{\\text{est}}-\\nabla f| < \\epsilon$\n",
     "* $d$ — dimensionality of $f$\n",
     "* $D_2$ — bound on the second derivative of $f$ near the origin\n",
     "\n",
-    "### Selecting $l$\n",
+    "#### Selecting $l$\n",
     "Choose $l$ to ensure the function remains approximately linear. Similar to classical numerical differentiation, this interval must be sufficiently small.\n",
     "\n",
     "To keep gradient variation within accuracy $\\epsilon$, we require $\\nabla f_{\\text{max}} - \\nabla f_{\\text{min}} \\le \\epsilon$.\n",
@@ -165,12 +165,12 @@
     "\n",
     "See Jordan's paper [\\[1\\]](#original_paper) for a full derivation.\n",
     "\n",
-    "### Selecting $m$\n",
+    "#### Selecting $m$\n",
     "The parameter $m$ bounds the gradient magnitude. Since the gradient is signed, we need $m \\ge 2\\nabla f_{\\text{max}}$.\n",
     "\n",
     "The resolution of the result is $\\frac{m}{N}$. For a given register size and accuracy $\\epsilon$, the upper bound is $m \\le 2N\\epsilon$.\n",
     "\n",
-    "### Selecting $n$\n",
+    "#### Selecting $n$\n",
     "$N=2^n$ defines the result resolution. The step size between possible outcomes is $\\frac{m}{N}$.\n",
     "\n",
     "To achieve accuracy $\\epsilon$, we need $N\\geq\\frac{m}{2\\epsilon}$.\n",
@@ -178,7 +178,7 @@
     "Assuming tight $m$ selection, this gives a lower bound for the number of qubits:\n",
     "$$n\\geq\\log_2\\left(\\frac{\\nabla f_{\\text{max}}}{\\epsilon}\\right)$$\n",
     "\n",
-    "### Summary\n",
+    "#### Summary\n",
     "Given $\\nabla f_{\\text{max}}$ and desired accuracy $\\epsilon$, select parameters as:\n",
     "\n",
     "\n",
@@ -194,7 +194,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "## Outline\n",
+    "### Outline\n",
     "This notebook covers:\n",
     "1. Theoretical foundation and parameter selection\n",
     "2. Implementation\n",
@@ -210,7 +210,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "# Implementation"
+    "## Implementation"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "## State Preparation"
+    "### State Preparation"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "id": "10",
    "metadata": {},
    "source": [
-    "### Phase Kickback"
+    "#### Phase Kickback"
    ]
   },
   {
@@ -801,7 +801,7 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "### Direct Phase"
+    "#### Direct Phase"
    ]
   },
   {
@@ -909,7 +909,7 @@
    "id": "22",
    "metadata": {},
    "source": [
-    "### Quadratic Function"
+    "#### Quadratic Function"
    ]
   },
   {
@@ -1083,7 +1083,7 @@
    "id": "27",
    "metadata": {},
    "source": [
-    "## Full Algorithm"
+    "### Full Algorithm"
    ]
   },
   {
@@ -1091,7 +1091,7 @@
    "id": "28",
    "metadata": {},
    "source": [
-    "### Implementation\n"
+    "#### Implementation\n"
    ]
   },
   {
@@ -1179,7 +1179,7 @@
    "id": "31",
    "metadata": {},
    "source": [
-    "### Linear Functions"
+    "#### Linear Functions"
    ]
   },
   {
@@ -1404,7 +1404,7 @@
    "id": "36",
    "metadata": {},
    "source": [
-    "### Quadratic Function"
+    "#### Quadratic Function"
    ]
   },
   {
@@ -1558,7 +1558,7 @@
    "id": "42",
    "metadata": {},
    "source": [
-    "# Performance Analysis"
+    "## Performance Analysis"
    ]
   },
   {
@@ -1773,7 +1773,7 @@
    "id": "47",
    "metadata": {},
    "source": [
-    "# Multi-Dimensional Examples"
+    "## Multi-Dimensional Examples"
    ]
   },
   {
@@ -1839,17 +1839,17 @@
    "id": "50",
    "metadata": {},
    "source": [
-    "# Summary and Discussion\n",
+    "## Summary and Discussion\n",
     "\n",
     "This notebook demonstrated Jordan's quantum gradient estimation algorithm, which estimates $\\nabla f$ at the origin using a **single query** to $f$, compared to the classical lower bound of $d+1$ queries.\n",
     "\n",
-    "## Algorithm\n",
+    "### Algorithm\n",
     "\n",
     "1. Prepare a uniform superposition over $N = 2^n$ sample points using Hadamard gates.\n",
     "2. Encode $f$ as phases, either via phase kickback from a state oracle or directly using a phase oracle.\n",
     "3. Apply the inverse QFT to map the phase encoding onto a measurable computational basis state containing $\\nabla f$.\n",
     "\n",
-    "## Parameter Selection\n",
+    "### Parameter Selection\n",
     "\n",
     "| Parameter | Role | Constraint |\n",
     "|---|---|---|\n",
@@ -1857,13 +1857,13 @@
     "| $m$ | Gradient range | $2\\nabla f_{\\max} \\leq m \\leq 2\\cdot2^n\\epsilon$ |\n",
     "| $n$ | Qubits / resolution | $n \\geq \\log_2(\\nabla f_{\\max} / \\epsilon)$ |\n",
     "\n",
-    "## Potential Use Cases\n",
+    "### Potential Use Cases\n",
     "\n",
     "The $d+1 \\to 1$ query reduction is most valuable when $d$ is large and each function evaluation is expensive.\n",
     "\n",
     "Potential applications include: Optimization, Root-finding, Functional minimization and PDEs and more.\n",
     "\n",
-    "## Limitation: Higher-Order Derivatives\n",
+    "### Limitation: Higher-Order Derivatives\n",
     "\n",
     "The algorithm **cannot be applied recursively** to compute second or higher-order derivatives of $f$.\n",
     "\n",
@@ -1877,8 +1877,8 @@
    "id": "51",
    "metadata": {},
    "source": [
-    "# Appendices\n",
-    "## Appendix 1 - Phase Kickback\n",
+    "## Appendices\n",
+    "### Appendix 1 - Phase Kickback\n",
     "\n",
     "We start with the state $|\\delta\\rangle|0\\rangle$ where $|\\delta\\rangle$ is a superposition created by the Hadamard gate for all the coordinates, hence:\n",
     "$$\\sum_{\\delta_1=0}^{N-1}\\cdots\\sum_{\\delta_d=0}^{N-1}|\\delta_1\\rangle\\cdots|\\delta_d\\rangle$$\n",
@@ -1920,7 +1920,7 @@
    "id": "52",
    "metadata": {},
    "source": [
-    "# References"
+    "## References"
    ]
   },
   {


### PR DESCRIPTION
## Problem

`algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb` has multiple top-level `#` (H1) headings. The `notebook-uniformity` lint hook requires a single H1 (the page title), so this currently fails lint on `main`.

## Fix

Demote every non-title heading by one level, uniformly:
- the single H1 title stays H1,
- the former H1 sections (Introduction, Implementation, Performance Analysis, Multi-Dimensional Examples, Summary and Discussion, Appendices, References) become H2,
- their existing H2 children become H3, and H3 grandchildren become H4.

This yields exactly one H1 and preserves the original section nesting (a plain "demote only the H1s" would flatten each section to the same level as its own subsections). Only heading lines changed; no code, outputs, or prose were touched, and all formatting hooks (prettier/black/nbformat) pass with no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)