### PR TITLE
Allow fork checkout in CI-main for actions/checkout v7

### DIFF
--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -46,6 +46,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       #
       # Setup Python


### PR DESCRIPTION
## Summary
- `actions/checkout@v7` now refuses to check out fork PR code from `pull_request_target` workflows by default (pwn-request protection)
- Added `allow-unsafe-pr-checkout: true` to the fork-checkout step in `Test-CI-main.yml`
- The other three `pull_request_target` workflows (`Notification-detect-new-notebooks`, `Notification-developers-onboarding`, `Internal-automatic-deployment`) don't check out fork code, so they're unaffected

## Test plan
- [ ] Open a PR from a fork and verify CI-main runs without the checkout error

🤖 Generated with [Claude Code](https://claude.com/claude-code)