### PR TITLE
Pre-commit tools: shared _common helper, cleanups, unified hook names

### DIFF
--- a/.internal/pre_commit_tools/_common.py
+++ b/.internal/pre_commit_tools/_common.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Shared helpers for the notebook / qmod pre-commit tools.
+
+Pre-commit runs each hook as `python <script>.py`, so the script's own directory
+is on sys.path and siblings import directly:
+
+    from _common import PROJECT_ROOT, is_tested, validate_unique_names
+
+(the same pattern metadata_validate uses for metadata_utils / metadata_consts.)
+"""
+
+import subprocess
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+
+PROJECT_ROOT = Path(subprocess.getoutput("git rev-parse --show-toplevel"))  # noqa: S605
+
+# Notebooks under these top-level areas are not part of the CI-tested core.
+_UNTESTED_DIRS = ("functions", "community")
+
+
+def is_tested(path) -> bool:
+    """True for a notebook we expect to carry a test (i.e. not community/functions)."""
+    parts = Path(path).parts
+    return not any(area in parts for area in _UNTESTED_DIRS)
+
+
+def iter_files(pattern: str, exclude_parts: Iterable[str] = ()) -> list[Path]:
+    """Repo files matching `pattern`, skipping checkpoints/.git and any `exclude_parts`."""
+    skip = (".ipynb_checkpoints", ".git", *exclude_parts)
+    return [
+        p
+        for p in PROJECT_ROOT.rglob(pattern)
+        if not any(part in p.parts for part in skip)
+    ]
+
+
+def validate_unique_names(
+    pattern: str, label: str, exclude_parts: Iterable[str] = ()
+) -> bool:
+    """Fail if two matching files share a basename (tests key off the basename)."""
+    names = [p.name for p in iter_files(pattern, exclude_parts)]
+    duplicates = [name for name, count in Counter(names).items() if count > 1]
+    if duplicates:
+        print(
+            f"File naming error: every {label} must have a unique basename "
+            f"(even across directories). Duplicates found: {duplicates}"
+        )
+    return not duplicates
+
+
+def validate_filename(file_path: str) -> bool:
+    """A notebook/qmod basename uses underscores — no dashes, no spaces."""
+    name = Path(file_path).name
+    errors = []
+    if "-" in name:
+        errors.append(
+            f"dash (-) is not allowed; use underscore (_), "
+            f"e.g. rename to '{file_path.replace('-', '_')}'"
+        )
+    if " " in name:
+        errors.append(
+            f"space is not allowed; use underscore (_), "
+            f"e.g. rename to '{file_path.replace(' ', '_')}'"
+        )
+    if errors:
+        spacing = "\n\t"  # f-string cannot include a backslash
+        print(f"File `{file_path}` has naming error(s):{spacing}{spacing.join(errors)}")
+    return not errors

--- a/.internal/pre_commit_tools/auto_add_tests.py
+++ b/.internal/pre_commit_tools/auto_add_tests.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
+"""Auto-create a placeholder test for each new CI-tested notebook.
+
+The generated test asserts on `tb.ref_pydantic("qprog")`; it is a *starting
+point* the notebook author is expected to fill in (a notebook without a `qprog`
+will fail until the author writes a real test — that is intentional).
+"""
 
 import sys
 from pathlib import Path
 from typing import Iterable
-import subprocess
 
-PROJECT_ROOT = Path(subprocess.getoutput("git rev-parse --show-toplevel"))  # noqa: S605
+from _common import PROJECT_ROOT, is_tested
 
 DEFAULT_TIMEOUTS_SECONDS = 60
 
@@ -19,43 +24,27 @@ def main() -> bool:
 
     result = True
     for notebook_file_path in _get_all_notebooks():
-        if not does_test_exist(notebook_file_path) and should_notebook_be_tested(
-            notebook_file_path
-        ):
+        if is_tested(notebook_file_path) and not does_test_exist(notebook_file_path):
             result = False
             auto_create_test(notebook_file_path)
     return result
 
 
 def _get_all_notebooks() -> Iterable[Path]:
-    all_notebooks: Iterable[Path]
-
     if "--all-files" in sys.argv:
-        all_notebooks = PROJECT_ROOT.rglob("*.ipynb")
-    else:
-        all_notebooks = [
-            Path(file)
-            for file in sys.argv[1:]
-            if (file.endswith(".ipynb") and (".ipynb_checkpoint" not in file))
-        ]
+        return PROJECT_ROOT.rglob("*.ipynb")
 
-        all_notebooks = [
-            p if p.is_absolute() else PROJECT_ROOT / p for p in all_notebooks
-        ]
-
-    return all_notebooks
+    notebooks = [
+        Path(file)
+        for file in sys.argv[1:]
+        if file.endswith(".ipynb") and ".ipynb_checkpoint" not in file
+    ]
+    return [p if p.is_absolute() else PROJECT_ROOT / p for p in notebooks]
 
 
 def does_test_exist(notebook_file_path: Path) -> bool:
     expected_test_name = f"test_{notebook_file_path.stem}.py"
     return bool(list(PROJECT_ROOT.rglob(expected_test_name)))
-
-
-def should_notebook_be_tested(notebook_file_path: Path) -> bool:
-    return not (
-        "functions" in notebook_file_path.parts
-        or "community" in notebook_file_path.parts
-    )
 
 
 def auto_create_test(notebook_file_path: Path) -> None:

--- a/.internal/pre_commit_tools/extra_nbstripout.py
+++ b/.internal/pre_commit_tools/extra_nbstripout.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import json
 import nbformat
 
 VERSION_MAJOR = 4
@@ -99,7 +98,7 @@ def strip_single_notebook(notebook_path: str) -> bool:
             nbformat.write(nb, notebook_path)
     except Exception as exc:
         result = False
-        print(f"Upgrading version failed for '{notebook_path}'. Error: {exc}")
+        print(f"Stripping metadata failed for '{notebook_path}'. Error: {exc}")
     return result
 
 

--- a/.internal/pre_commit_tools/notebook_pre_commit_collection.py
+++ b/.internal/pre_commit_tools/notebook_pre_commit_collection.py
@@ -1,77 +1,16 @@
 #!/usr/bin/env python3
-# ruff: noqa: F841,E713
+"""Validate notebook file names: unique basenames, underscores (no dash/space)."""
 
-import os
-import subprocess
 import sys
-from collections import Counter
 from collections.abc import Iterable
-from pathlib import Path
 
-PROJECT_ROOT = Path(subprocess.getoutput("git rev-parse --show-toplevel"))  # noqa: S605
+from _common import validate_filename, validate_unique_names
 
 
 def main(full_file_paths: Iterable[str]) -> bool:
-    return validate_unique_names() and all(map(is_valid_notebook, full_file_paths))
-
-
-def is_valid_notebook(file_path: str, automatically_add_timeout: bool = True) -> bool:
-    file_name = os.path.basename(file_path)
-
-    errors = []
-
-    if _does_contain_dash_in_file_name(file_name):
-        errors.append(
-            "File naming format error:\n"
-            "    Dash (-) is not allowed in file name. please use underscore (_)\n"
-            f"    for example, you may change '{file_path}' to '{file_path.replace('-', '_')}'."
-        )
-
-    if _does_contain_space_in_file_name(file_name):
-        errors.append(
-            "File naming format error:\n"
-            "    Space is not allowed in file name. please use underscore (_)\n"
-            f"    for example, you may change '{file_path}' to '{file_path.replace(' ', '_')}'."
-        )
-
-    if errors:
-        spacing = "\n\t"  # f-string cannot include backslash
-        print(f"File `{file_path}` has error(s):{spacing}{spacing.join(errors)}")
-
-    return not errors
-
-
-def should_notebook_be_tested(file_path: str) -> bool:
-    return not ("/functions/" in file_path or "/community/" in file_path)
-
-
-def _does_contain_dash_in_file_name(file_name: str) -> bool:
-    return "-" in file_name
-
-
-def _does_contain_space_in_file_name(file_name: str) -> bool:
-    return " " in file_name
-
-
-def validate_unique_names() -> bool:
-    all_files = PROJECT_ROOT.rglob("*.ipynb")
-    base_names = [
-        file.name
-        for file in all_files
-        if ".ipynb_checkpoints" not in file.parts and ".git" not in file.parts
-    ]
-
-    duplicate_names = [name for name, count in Counter(base_names).items() if count > 1]
-
-    if duplicate_names:
-        print(
-            "File naming error:\n"
-            "    There is a requirement that each notebook will have a unique names. No two files with the same name, even if the files sit in different directories.\n"
-            f"    However, the following notebooks were found with duplicate names: {duplicate_names}"
-        )
-
-    is_ok = not duplicate_names
-    return is_ok
+    names_ok = validate_unique_names("*.ipynb", "notebook")
+    files_ok = all([validate_filename(path) for path in full_file_paths])
+    return names_ok and files_ok
 
 
 if __name__ == "__main__":

--- a/.internal/pre_commit_tools/qmod_pre_commit_collection.py
+++ b/.internal/pre_commit_tools/qmod_pre_commit_collection.py
@@ -1,90 +1,19 @@
 #!/usr/bin/env python3
-# ruff: noqa: F841,E713
+"""Validate qmod file names: unique basenames, underscores (no dash/space).
 
-import os
-import subprocess
+Uniqueness excludes `functions/` (its qmods may legitimately share basenames).
+"""
+
 import sys
-from collections import Counter
 from collections.abc import Iterable
-from pathlib import Path
 
-PROJECT_ROOT = Path(subprocess.getoutput("git rev-parse --show-toplevel"))  # noqa: S605
+from _common import validate_filename, validate_unique_names
 
 
 def main(full_file_paths: Iterable[str]) -> bool:
-    return validate_unique_names() and all(map(is_valid_qmod, full_file_paths))
-
-
-def is_valid_qmod(
-    file_path: str,
-    automatically_add_timeout: bool = True,
-    assert_if_fails: bool = False,
-) -> bool:
-    file_name = os.path.basename(file_path)
-
-    errors = []
-
-    if _does_contain_dash_in_file_name(file_name):
-        errors.append(
-            "File naming format error:\n"
-            "    Dash (-) is not allowed in file name. please use underscore (_)\n"
-            f"    for example, you may change '{file_path}' to '{file_path.replace('-', '_')}'."
-        )
-
-    if _does_contain_space_in_file_name(file_name):
-        errors.append(
-            "File naming format error:\n"
-            "    Space is not allowed in file name. please use underscore (_)\n"
-            f"    for example, you may change '{file_path}' to '{file_path.replace(' ', '_')}'."
-        )
-
-    spacing = "\n\t"  # f-string cannot include backslash
-    errors_combined_message = (
-        f"File `{file_path}` has error(s):{spacing}{spacing.join(errors)}"
-    )
-
-    if assert_if_fails:
-        assert not errors, errors_combined_message
-    else:
-        if errors:
-            print(errors_combined_message)
-
-        return not errors
-
-
-def should_notebook_be_tested(file_path: str) -> bool:
-    return not ("functions/" in file_path or "community/" in file_path)
-
-
-def _does_contain_dash_in_file_name(file_name: str) -> bool:
-    return "-" in file_name
-
-
-def _does_contain_space_in_file_name(file_name: str) -> bool:
-    return " " in file_name
-
-
-def validate_unique_names() -> bool:
-    all_files: Iterable[Path] = PROJECT_ROOT.rglob("*.qmod")
-    # exclude `functions/`
-    all_files = [
-        path
-        for path in all_files
-        if ("functions" not in path.parts) and (".ipynb_checkpoints" not in path.parts)
-    ]
-    base_names = [file.name for file in all_files]
-
-    duplicate_names = [name for name, count in Counter(base_names).items() if count > 1]
-
-    if duplicate_names:
-        print(
-            "File naming error:\n"
-            "    There is a requirement that each qmod file will have a unique names. No two files with the same name, even if the files sit in different directories.\n"
-            f"    However, the following qmods were found with duplicate names: {duplicate_names}"
-        )
-
-    is_ok = not duplicate_names
-    return is_ok
+    names_ok = validate_unique_names("*.qmod", "qmod file", exclude_parts={"functions"})
+    files_ok = all([validate_filename(path) for path in full_file_paths])
+    return names_ok and files_ok
 
 
 if __name__ == "__main__":

--- a/.internal/pre_commit_tools/set_nbformat.py
+++ b/.internal/pre_commit_tools/set_nbformat.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import json
 import nbformat
 
 VERSION_MAJOR = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,35 +6,41 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-case-conflict
+        name: forbid    case conflict
       - id: check-executables-have-shebangs
+        name: validate  shebangs
       - id: check-merge-conflict
+        name: forbid    merge conflict
       - id: check-symlinks
+        name: validate  symlinks
       - id: check-json
+        name: validate  json
       - id: check-yaml
+        name: validate  yaml
       - id: end-of-file-fixer
-        name: format end of file
+        name: format    end of file
       - id: trailing-whitespace
-        name: format trailing whitespace
+        name: format    trailing whitespace
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.9.6
     hooks:
       - id: prettier
-        name: format prettier
+        name: format    prettier
   - repo: https://github.com/psf/black
     rev: 26.5.1
     hooks:
       - id: black-jupyter
-        name: format notebook black
+        name: format    notebook black
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1
     hooks:
       - id: nbqa-isort
-        name: format notebook isort
+        name: format    notebook isort
 
   - repo: local
     hooks:
       - id: upgrade-nbformat
-        name: format nbformat upgrade
+        name: format    nbformat upgrade
         entry: .internal/pre_commit_tools/set_nbformat.py
         language: python
         files: \.ipynb$
@@ -42,7 +48,7 @@ repos:
           - "nbformat"
         require_serial: true
       - id: extra-nbstripout
-        name: format nbformat strip
+        name: format    nbformat strip
         entry: .internal/pre_commit_tools/extra_nbstripout.py
         language: python
         files: \.ipynb$
@@ -50,7 +56,7 @@ repos:
           - "nbformat"
         require_serial: true
       - id: verify-notebook-format-execution-count
-        name: format nbformat execution-count
+        name: forbid    negative execution-count
         language: pygrep
         files: \.ipynb$
         entry: '"execution_count": -'
@@ -59,7 +65,7 @@ repos:
     rev: 0.9.1
     hooks:
       - id: nbstripout
-        name: format nbformat nbstripout
+        name: format    nbformat nbstripout
         args:
           [
             --keep-output,
@@ -71,54 +77,54 @@ repos:
   - repo: local
     hooks:
       - id: verify-platform-links-nightly
-        name: Forbid links to nightly.platform
+        name: forbid    nightly-platform links
         language: pygrep
         files: \.ipynb$
         exclude: (^|/)logical_qubits_by_alice_and_bob\.ipynb$
         entry: https://nightly\.platform\.classiq\.io
       - id: verify-platform-links-dev
-        name: Forbid links with dev version
+        name: forbid    dev-version links
         language: pygrep
         files: \.ipynb$
         exclude: (^|/)logical_qubits_by_alice_and_bob\.ipynb$
         entry: '[?&]version=[^ \t\n]*\.dev'
       - id: verify-platform-links-old
-        name: Forbid links from older versions
+        name: forbid    older-version links
         language: pygrep
         files: \.ipynb$
         exclude: (^|/)logical_qubits_by_alice_and_bob\.ipynb$
         entry: '"Opening:\s+https://'
 
       - id: notebook-pre-commit
-        name: Validate naming notebooks
+        name: validate  notebook names
         description: Ensure notebooks conventions
         entry: .internal/pre_commit_tools/notebook_pre_commit_collection.py
         language: python
         files: \.ipynb$
         require_serial: true
       - id: qmod-pre-commit
-        name: Validate naming qmods
+        name: validate  qmod names
         description: Ensure qmods conventions
         entry: .internal/pre_commit_tools/qmod_pre_commit_collection.py
         language: python
         files: \.qmod$
         require_serial: true
       - id: validate-metadata-file
-        name: Validate Metadata file
+        name: validate  metadata
         description: Add file if non existant and validate value otherwise
         entry: .internal/pre_commit_tools/metadata_validate.py
         language: python
         files: \.(qmod|ipynb)$
         require_serial: true
       - id: auto-add-tests
-        name: Auto add test
+        name: format    add tests
         description: Automatically adding a test to new notebooks
         entry: .internal/pre_commit_tools/auto_add_tests.py
         language: python
         files: \.ipynb$
         require_serial: true
       - id: notebook-uniformity
-        name: Enforce notebook uniformity
+        name: format    uniformity
         description: Auto-fix simple uniformity conventions (e.g. plural "References" heading)
         entry: .internal/pre_commit_tools/notebook_uniformity.py
         language: python


### PR DESCRIPTION
Two small, independent improvements to the notebook/qmod pre-commit tooling. No change to *what* is validated or fixed.

### 1. Shared `_common.py` + cleanups (`428793d9`)
- New `.internal/pre_commit_tools/_common.py`: `PROJECT_ROOT`, `is_tested`, `iter_files`, `validate_unique_names`, `validate_filename` — imported as a plain sibling (same pattern `metadata_validate` already uses for `metadata_utils`; no `sys.path` juggling).
- `notebook_pre_commit_collection.py` / `qmod_pre_commit_collection.py` become thin wrappers over the shared helpers. This removes the duplicated `PROJECT_ROOT` / `validate_unique_names`, the dead `should_notebook_be_tested`, and unused params — and **fixes a latent inconsistency**: the "is this tested?" check was implemented three different ways (`"/functions/" in path` vs `"functions" in path.parts`); it's now one robust `path.parts` check.
- Filename errors now report **all** offenders in a file, not just the first.
- `auto_add_tests.py` uses the shared `is_tested`.
- `set_nbformat.py` / `extra_nbstripout.py`: drop an unused `import json`; fix the misleading "Upgrading version failed" message in the metadata stripper.

### 2. Unified hook names: `format` / `validate` / `forbid` (`e3b869e9`)
Every hook's display name now starts with one of three aligned verbs, so a red line tells you immediately what happened:
- **`format`** — it changed your files (re-`git add`)
- **`validate`** — a required property is missing
- **`forbid`** — a banned pattern is present

Names only — **hook order and behaviour are unchanged** (the fixers still run in their existing dependency order). Also adds names to the six `check-*` hooks that had none, and re-labels the previously mislabeled `format nbformat execution-count` (it's a check) as `forbid negative execution-count`.

### Verification
- Each refactored script was run **invoked by path** (the way pre-commit calls it) to confirm the sibling import resolves and behaviour is unchanged; a bad filename still fails.
- `prettier` preserves the aligned names (its hook passes clean).