### PR TITLE
Add pre-commit hook to validate LaTeX in notebooks

### DIFF
--- a/.internal/pre_commit_tools/notebook_validate_latex.py
+++ b/.internal/pre_commit_tools/notebook_validate_latex.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import sys
+
+import latex2mathml.converter
+
+_LATEX_PATTERN = re.compile("(?<!\\\\)(\\${1,2})(.*?)\\1", re.DOTALL)
+
+
+def main() -> bool:
+    result = True
+    for filepath in sys.argv[1:]:
+        if filepath.endswith(".ipynb"):
+            result &= validate_latex(filepath)
+    return result
+
+
+def validate_latex(filepath: str) -> bool:
+    with open(filepath, encoding="utf-8") as f:
+        notebook = json.load(f)
+
+    result = True
+    for cell_idx, cell in enumerate(notebook.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+
+        source = "".join(cell.get("source", []))
+        for match in _LATEX_PATTERN.finditer(source):
+            math_str = match.group(2)
+            if not math_str.strip():
+                continue
+
+            try:
+                latex2mathml.converter.convert(math_str)
+            except Exception as e:
+                result = False
+                snippet = math_str.strip()[:50]
+                print(f"{filepath} | cell {cell_idx}: invalid LaTeX: {snippet}...")
+                print(f"  {e}")
+
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(not main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,16 @@ repos:
         exclude: (^|/)logical_qubits_by_alice_and_bob\.ipynb$
         entry: '"Opening:\s+https://'
 
+      - id: validate-latex
+        name: validate  notebook LaTeX
+        description: Ensure LaTeX math expressions in markdown cells are valid
+        entry: .internal/pre_commit_tools/notebook_validate_latex.py
+        language: python
+        files: \.ipynb$
+        additional_dependencies:
+          - "latex2mathml"
+        require_serial: true
+
       - id: notebook-pre-commit
         name: validate  notebook names
         description: Ensure notebooks conventions


### PR DESCRIPTION
## Summary
- Adds a `validate-latex` pre-commit hook that checks `$...$` and `$$...$$` math expressions in notebook markdown cells using `latex2mathml`
- New script at `.internal/pre_commit_tools/notebook_validate_latex.py`
- Passes on all existing notebooks (zero false positives)

## Test plan
- [x] Valid LaTeX notebook passes
- [x] Invalid LaTeX notebook correctly rejected with error details
- [x] `pre-commit run validate-latex --all-files` passes on entire repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)