### PR TITLE
Regenerate dqi_max_xorsat qmod with inlined inplace_binary_to_one_hot

### DIFF
--- a/algorithms/search_and_optimization/dqi/dqi_max_xorsat.qmod
+++ b/algorithms/search_and_optimization/dqi/dqi_max_xorsat.qmod
@@ -1,24 +1,25 @@
-qperm inplace_binary_to_one_hot_expanded___0(qvar: qbit[4]) {
+qperm inplace_binary_to_one_hot_expanded___0(input source: qbit[4], output target: qbit[4]) {
   x0: qbit;
   x1: qbit;
   x2: qbit;
   x3: qbit;
-  qvar -> {x0, x1, x2, x3};
-  {x2, x0, x3, x1} -> qvar;
-  X(qvar[0]);
-  CX(qvar[1], qvar[0]);
-  control (qvar[3]) {
-    SWAP(qvar[0], qvar[2]);
+  source -> {x0, x1, x2, x3};
+  {x2, x0, x3, x1} -> target;
+  X(target[0]);
+  CX(target[1], target[0]);
+  control (target[3]) {
+    SWAP(target[0], target[2]);
   }
-  CX(qvar[2], qvar[3]);
-  CX(qvar[3], qvar[1]);
+  CX(target[2], target[3]);
+  CX(target[3], target[1]);
 }
 
 qperm binary_to_one_hot_expanded___0(input binary: qnum<2, False, 0>, output one_hot: qbit[4]) {
   extension: qbit[2];
   allocate(2, extension);
-  {binary, extension} -> one_hot;
-  inplace_binary_to_one_hot_expanded___0(one_hot);
+  padded: qbit[4];
+  {binary, extension} -> padded;
+  inplace_binary_to_one_hot_expanded___0(padded, one_hot);
 }
 
 qperm inplace_one_hot_to_unary_expanded___0(qvar: qbit[4]) {


### PR DESCRIPTION
### PR Description

<!-- Describe the PR's general purpose -->

### Some notes

- [ ] Please make sure that the notebook runs successfully with the latest Classiq version.

- [ ] Please make sure that you placed the files in an appropriate folder

  - [ ] And that the file names are clear, descriptive, and match the notebook content.
    - [ ] Note that we require the file names of `.ipynb` and `.qmod` to be unique across this repository.
  - [ ] Plus, please make sure that all required files are included: `.qmod`, `.synthesis_options.json`, `.metadata.json`
  - [ ] And that images are embedded inside the notebook, not added as external files

- [ ] If applicable, please include link to the paper on which the notebook is based, in the notebook itself.

- [ ] Please use `rebase` on your branch (no merge commits)
- [ ] Please link this PR to the relevant issue

- [ ] Please make sure to run `pre-commit` when commiting changes
  - [ ] If you're using `git` in the terminal, make sure to install `pre-commit` via running `pip install pre-commit` followed by `pre-commit install`
    - [ ] More info at [the `pre-commit` documentation](https://pre-commit.com/)
  - [ ] Note that Classiq runs automatic code linting. Meaning that one of the tests verifies the output of `pre-commit`.
  - [ ] Also note that `pre-commit` may minorly alter some files. Make sure to `git add` the changes done by `pre-commit`
