### PR TITLE
Add reminder about updating tests when fixing notebook conventions

### DIFF
--- a/.internal/conventions/README.md
+++ b/.internal/conventions/README.md
@@ -30,3 +30,6 @@ voice across the ~219 notebooks. Run everything from the **repo root**.
 The simple, safe rules are also **enforced** in the pre-commit hook at
 `.internal/pre_commit_tools/notebook_uniformity.py` (currently: references plural,
 `result_value`, `show(qprog)`, opens-with-an-H1-title, and single-H1).
+
+**Note:** Some fixes (e.g. variable renames) may also require updating the
+corresponding test file at `tests/notebooks/test_<notebook_name>.py`.

--- a/.internal/conventions/report.py
+++ b/.internal/conventions/report.py
@@ -386,6 +386,15 @@ def main() -> None:
             _print_point_summary(results)
         _print_legend(results)
 
+    if not args.list:
+        print(
+            Ansi.paint(
+                "\n  Note: some fixes (e.g. variable renames) may also require updating "
+                "the corresponding test in tests/notebooks/test_<notebook>.py",
+                Ansi.DIM,
+            )
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Adds a note to `.internal/conventions/README.md` reminding that some fixes require updating the corresponding test file
- Adds a print statement at the end of `report.py` output with the same reminder

This helps prevent overlooking `tests/notebooks/test_<notebook>.py` when applying convention fixes that rename variables.

## Test plan
- [x] Run `python .internal/conventions/report.py` and verify the note appears at the bottom

🤖 Generated with [Claude Code](https://claude.ai/claude-code)