### PR TITLE
Fix qprog_var convention in cooling_systems_optimization notebook

### DIFF
--- a/applications/automotive/cooling_systems_optimization/cooling_systems_optimization.ipynb
+++ b/applications/automotive/cooling_systems_optimization/cooling_systems_optimization.ipynb
@@ -788,13 +788,13 @@
     }
    ],
    "source": [
-    "matrix_inverse_qprog = synthesize(\n",
+    "qprog_matrix_inverse = synthesize(\n",
     "    main,\n",
     "    preferences=Preferences(\n",
     "        transpilation_option=\"none\", timeout_seconds=14400, optimization_level=1\n",
     "    ),\n",
     ")\n",
-    "show(matrix_inverse_qprog)"
+    "show(qprog_matrix_inverse)"
    ]
   },
   {
@@ -820,7 +820,7 @@
     }
    ],
    "source": [
-    "sv = calculate_state_vector(matrix_inverse_qprog, filters={\"qsvt_aux\": 0, \"block\": 0})\n",
+    "sv = calculate_state_vector(qprog_matrix_inverse, filters={\"qsvt_aux\": 0, \"block\": 0})\n",
     "\n",
     "T_tilde = np.zeros(4, dtype=complex)\n",
     "for _, row in sv.iterrows():\n",
@@ -1361,13 +1361,13 @@
     }
    ],
    "source": [
-    "dummy_qprog = synthesize(\n",
+    "qprog_dummy = synthesize(\n",
     "    main,\n",
     "    preferences=Preferences(\n",
     "        transpilation_option=\"none\", timeout_seconds=14400, optimization_level=1\n",
     "    ),\n",
     ")\n",
-    "show(dummy_qprog)"
+    "show(qprog_dummy)"
    ]
   },
   {

--- a/tests/notebooks/test_cooling_systems_optimization.py
+++ b/tests/notebooks/test_cooling_systems_optimization.py
@@ -18,12 +18,12 @@ def test_notebook(tb: TestbookNotebookClient) -> None:
         expected_depth=None,  # no transpilation
     )
     validate_quantum_program_size(
-        tb.ref_pydantic("matrix_inverse_qprog"),
+        tb.ref_pydantic("qprog_matrix_inverse"),
         expected_width=16,  # actual width: 11
         expected_depth=None,  # no transpilation
     )
     validate_quantum_program_size(
-        tb.ref_pydantic("dummy_qprog"),
+        tb.ref_pydantic("qprog_dummy"),
         expected_width=16,  # actual width: 11
         expected_depth=None,  # no transpilation
     )


### PR DESCRIPTION
## Summary
- Renames `synthesize()` output variables to use the suffix form per the `qprog_var` convention:
  - `dummy_qprog` → `qprog_dummy`
  - `matrix_inverse_qprog` → `qprog_matrix_inverse`
- Updates the corresponding test file with matching variable names

This brings the `qprog_var` point to 100% (219/219 notebooks).

## Test plan
- [x] Run `python .internal/conventions/report.py --rule qprog_var` and verify 100%
- [x] Verify notebook JSON is valid
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)