### PR TITLE
fix: normalize title case in notebook headings

### DIFF
--- a/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
+++ b/algorithms/quantum_primitives/gradient_estimation/gradient_estimation.ipynb
@@ -65,7 +65,7 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "### Simplified explanation of the algorithm\n",
+    "### Simplified Explanation of the Algorithm\n",
     "The algorithm has two main steps:\n",
     "1. Encode the function into the phases of the coordinate register's superposition\n",
     "2. Apply an inverse QFT to transform the coordinate register directly into the measurable gradient state\n",
@@ -105,7 +105,7 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "### Full explanation of the algorithm\n",
+    "### Full Explanation of the Algorithm\n",
     "The simplified explanation captures the key idea but omits two important details: handling negative values and fractional representation.\n",
     "\n",
     "When estimating the gradient, we analyze an interval $l$ around the origin.\n",

--- a/algorithms/search_and_optimization/quantum_likelihood_estimation/quantum_likelihood_estimation.ipynb
+++ b/algorithms/search_and_optimization/quantum_likelihood_estimation/quantum_likelihood_estimation.ipynb
@@ -220,7 +220,7 @@
    "id": "12",
    "metadata": {},
    "source": [
-    "## Classical functions for maximum likelihood"
+    "## Classical Functions for Maximum Likelihood"
    ]
   },
   {
@@ -543,7 +543,7 @@
    "id": "23",
    "metadata": {},
    "source": [
-    "### Plotting the convergence history"
+    "### Plotting the Convergence History"
    ]
   },
   {
@@ -977,7 +977,7 @@
    "id": "37",
    "metadata": {},
    "source": [
-    "### Plotting the convergence history"
+    "### Plotting the Convergence History"
    ]
   },
   {

--- a/tutorials/workshops/finance_workshops/rainbow_options_workshop_bruteforce.ipynb
+++ b/tutorials/workshops/finance_workshops/rainbow_options_workshop_bruteforce.ipynb
@@ -184,7 +184,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "### SANITY CHECK"
+    "### Sanity Check"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fix heading title case issues in 3 notebooks (non-conflicting with #1703)
- 39 notebooks reviewed by agents, 36 already correct

## Changes
- **gradient_estimation**: capitalize "Simplified/Full Explanation of the Algorithm"
- **quantum_likelihood**: capitalize "Classical Functions for Maximum Likelihood", "Plotting the Convergence History" (2x)
- **rainbow_options**: fix "SANITY CHECK" → "Sanity Check"

## Agent edge-case handling
The agents correctly handled several edge cases:
- **Math variables**: "Normalized b" kept lowercase (refers to vector $\vec{b}$)
- **Sentence-like headings**: Long explanatory headings kept as-is
- **All-caps non-acronyms**: "SANITY CHECK" converted to "Sanity Check"

## Detector limitations (not addressed here)
The `title_case` detector has false positives for:
- Headings with LaTeX math variables (e.g., "Selecting $l$") - the `l` triggers the sentence-case heuristic
- Headings with many minor words (e.g., "Guidance for the Workshop:") - <60% capitalization threshold triggers

These are correctly Title Case but the detector's heuristic is too simple. Improvement tracked separately.

## Test plan
- [x] `python .internal/conventions/report.py --rule title_case` shows 121→121 main (1 notebook fixed, detector flags false positives)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)