### PR TITLE
Fix reversed Suzuki-Trotter inequality and gamma_2 computation in qpe_for_molecules

### DIFF
--- a/applications/chemistry/qpe_for_molecules/qpe_for_molecules.ipynb
+++ b/applications/chemistry/qpe_for_molecules/qpe_for_molecules.ipynb
@@ -339,7 +339,7 @@
     "\n",
     "To approximate the Hamiltonian simulation $e^{2\\pi i H}$, use the Classiq built-in implementation for [Suzuki-Trotter formulas](https://github.com/Classiq/classiq-library/blob/main/functions/qmod_library_reference/qmod_core_library/hamiltonian_evolution/suzuki_trotter/suzuki_trotter.ipynb). For a given Suzuki-Trotter order $o$, you can specify a repetition parameter $r$ that controls the level of approximation. The literature provides lower bounds for $r$ as a function of the operator error $\\epsilon$ (defined by the diamond norm [[3](#Dimond)]). For example, Eq. (14) in Ref. [[2](#Bounds)] states that the Suzuki-Trotter formula of order 2 approximates $e^{i \\sum \\alpha_m P_m t}$ up to an error $\\epsilon$, given $r$ repetitions that satisfies\n",
     "$$\n",
-    "r \\leq \\left(\\frac{2^5\\gamma_2}{3\\epsilon}\\right)^{1/2}  t^{3/2},\n",
+    "r \\geq \\left(\\frac{2^5\\gamma_2}{3\\epsilon}\\right)^{1/2}  t^{3/2},\n",
     "\\tag{1}\n",
     "$$\n",
     "where $\\gamma_2 \\equiv \\sum_{l,m,n} |\\alpha_m\\alpha_n\\alpha_l| \\left |\\left[P_l,\\left[P_m, P_n\\right]\\right]\\right|_\\infty$. **In particular, note that the number of repetitions grows as $t^{3/2}$**.\n",
@@ -362,35 +362,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import itertools\n",
-    "\n",
-    "from openfermion import QubitOperator\n",
-    "from openfermion.utils import commutator\n",
+    "from itertools import product\n",
     "\n",
     "\n",
     "def calculate_gamma_2(hamiltonian):\n",
     "    \"\"\"\n",
-    "    Compute the $\\gamma_2$ value appearing in the bound for Suzuki Trotter of order 2\n",
-    "    \"\"\"\n",
-    "    gamma_2 = 0\n",
-    "    for triplet in itertools.combinations(range(len(hamiltonian.terms)), 3):\n",
-    "        terms = [list(hamiltonian.terms.keys())[index] for index in triplet]\n",
-    "        values = [list(hamiltonian.terms.values())[index] for index in triplet]\n",
-    "        factor = np.abs(values[0] * values[1] * values[2])\n",
-    "        inner_commutator = commutator(\n",
-    "            QubitOperator(terms[1], 1), QubitOperator(terms[0], 1)\n",
-    "        ).induced_norm()\n",
-    "        if inner_commutator != 0:\n",
-    "            outer_commutator = (\n",
-    "                2\n",
-    "                * commutator(\n",
-    "                    QubitOperator(terms[2], 1),\n",
-    "                    QubitOperator(terms[0], 1) * QubitOperator(terms[1], 1),\n",
-    "                ).induced_norm()\n",
-    "            )\n",
-    "            gamma_2 += factor * outer_commutator\n",
+    "    Compute the $\\gamma_2$ value appearing in the bound for Suzuki-Trotter of order 2.\n",
     "\n",
-    "    return gamma_2"
+    "    Uses the triangle inequality over Pauli coefficients to upper bound the\n",
+    "    spectral norm of each nested commutator (each Pauli string has unit norm).\n",
+    "    \"\"\"\n",
+    "    qmod_hamiltonian = qubit_op_to_qmod(hamiltonian)\n",
+    "    terms = [\n",
+    "        SparsePauliOp(terms=[term], num_qubits=qmod_hamiltonian.num_qubits)\n",
+    "        for term in qmod_hamiltonian.terms\n",
+    "    ]\n",
+    "    return sum(\n",
+    "        sum(\n",
+    "            abs(term.coefficient)\n",
+    "            for term in commutator(P_l, commutator(P_m, P_n)).terms\n",
+    "        )\n",
+    "        for P_l, P_m, P_n in product(terms, repeat=3)\n",
+    "    )"
    ]
   },
   {
@@ -444,7 +437,7 @@
      "output_type": "stream",
      "text": [
       "The theoretical bounds for the repetitions for QPE size 7, keeping an error 0.1 per QPE iteration are:\n",
-      "[   5.   12.   33.   93.  261.  737. 2084.]\n"
+      "[  11.   29.   82.  231.  651. 1841. 5206.]\n"
      ]
     }
    ],
@@ -478,7 +471,7 @@
      "output_type": "stream",
      "text": [
       "The repetitions for QPE size 7, taking a naive QPE, per QPE iteration:\n",
-      "[  5.   9.  17.  33.  66. 131. 261.]\n"
+      "[ 11.  21.  41.  82. 163. 326. 651.]\n"
      ]
     }
    ],


### PR DESCRIPTION
Closes #1707

Two corrections to the Suzuki-Trotter repetition-bound section of `applications/chemistry/qpe_for_molecules/qpe_for_molecules.ipynb`.

## 1. Eq. (1) had the inequality reversed

$$r \leq \left(\frac{2^5\gamma_2}{3\epsilon}\right)^{1/2} t^{3/2} \quad\longrightarrow\quad r \geq \left(\frac{2^5\gamma_2}{3\epsilon}\right)^{1/2} t^{3/2}$$

This is a *lower* bound on the repetitions needed to hold the operator error to $\epsilon$. As written with $\leq$, $r=1$ trivially satisfied it, making the bound vacuous — and contradicting both the preceding text ("lower bounds for $r$") and the sentence right after it ("the number of repetitions grows as $t^{3/2}$").

## 2. `calculate_gamma_2` did not match its own definition

The notebook defines

$$\gamma_2 \equiv \sum_{l,m,n} |\alpha_l \alpha_m \alpha_n| \, \bigl\| [P_l,[P_m,P_n]] \bigr\|_\infty$$

The previous implementation diverged in two ways:

- `itertools.combinations(range(len(hamiltonian.terms)), 3)` yields only **distinct, unordered** triples, whereas the sum runs over all ordered triples $l,m,n$ — so every term with a repeated index was dropped.
- It computed `2 * ||[P_l, P_m * P_n]||` instead of the nested commutator $\|[P_l,[P_m,P_n]]\|$.

Both errors bias $\gamma_2$ downward, understating the bound.

It is now computed over `itertools.product(terms, repeat=3)` with a genuine nested commutator, using Classiq's `SparsePauliOp` / `commutator` via `qubit_op_to_qmod` — which the notebook already imports and uses in its `suzuki_trotter` call. Each nested commutator's spectral norm is upper bounded by the sum of the absolute values of its Pauli coefficients (triangle inequality; each Pauli string has unit spectral norm), so the resulting bound stays conservative. This also drops the `openfermion.utils.commutator` / `QubitOperator` dependency from the cell.

```python
from itertools import product


def calculate_gamma_2(hamiltonian):
    qmod_hamiltonian = qubit_op_to_qmod(hamiltonian)
    terms = [
        SparsePauliOp(terms=[term], num_qubits=qmod_hamiltonian.num_qubits)
        for term in qmod_hamiltonian.terms
    ]
    return sum(
        sum(
            abs(term.coefficient)
            for term in commutator(P_l, commutator(P_m, P_n)).terms
        )
        for P_l, P_m, P_n in product(terms, repeat=3)
    )
```

## Effect on outputs

For the LiH Hamiltonian in the notebook (49 Pauli strings after trimming at threshold 0.03), $\gamma_2 = 0.003907$ and `theoretical_r0` goes from ~4.1 to ~10.17. The two dependent cells are regenerated:

| cell | before | after |
|---|---|---|
| 23 — theoretical bounds | `[5. 12. 33. 93. 261. 737. 2084.]` | `[11. 29. 82. 231. 651. 1841. 5206.]` |
| 25 — naive QPE | `[5. 9. 17. 33. 66. 131. 261.]` | `[11. 21. 41. 82. 163. 326. 651.]` |

## Scope

`gamma_2` / `theoretical_r0` only feed the printed pedagogical bounds in cells 23 and 25. The synthesized model uses `experimental_r0` (cell 29), so **`.qmod` and `.synthesis_options.json` are unchanged** and need no regeneration. No new files, so no metadata/timeout entries are required.

## Verification

- Ran the notebook's classical preamble against `classiq==1.25.0` and confirmed the new `calculate_gamma_2` executes and reproduces the committed cell 23/25 outputs exactly (re-checked after `black` reformatting).
- `pre-commit run --files applications/chemistry/qpe_for_molecules/qpe_for_molecules.ipynb` passes clean.
- Branched from current `main` with no merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)