### PR TITLE
refactor(notebooks): rename result -> df for sample() return values

### DIFF
--- a/algorithms/amplitude_amplification_and_estimation/qmc_user_defined/qmc_user_defined.ipynb
+++ b/algorithms/amplitude_amplification_and_estimation/qmc_user_defined/qmc_user_defined.ipynb
@@ -467,7 +467,7 @@
     }
    ],
    "source": [
-    "result = sample(qprog_3)"
+    "df = sample(qprog_3)"
    ]
   },
   {
@@ -478,7 +478,7 @@
    "outputs": [],
    "source": [
     "## mapping between register string to phases\n",
-    "phases_counts = dict(zip(result[\"phase_\"], result[\"counts\"]))"
+    "phases_counts = dict(zip(df[\"phase_\"], df[\"counts\"]))"
    ]
   },
   {

--- a/algorithms/amplitude_amplification_and_estimation/qsvt_fixed_point_amplitude_amplification/qsvt_fixed_point_amplitude_amplification.ipynb
+++ b/algorithms/amplitude_amplification_and_estimation/qsvt_fixed_point_amplitude_amplification/qsvt_fixed_point_amplitude_amplification.ipynb
@@ -356,7 +356,7 @@
     }
    ],
    "source": [
-    "result = sample(qprog)"
+    "df = sample(qprog)"
    ]
   },
   {
@@ -382,7 +382,7 @@
     "\n",
     "measured_good_shots = 0\n",
     "\n",
-    "for _, r in result.iterrows():\n",
+    "for _, r in df.iterrows():\n",
     "    a, b, c, aux = (\n",
     "        r[\"state.a\"],\n",
     "        r[\"state.b\"],\n",
@@ -425,7 +425,7 @@
    "source": [
     "poly_cheb = np.polynomial.Chebyshev(pcoefs)\n",
     "p_good_shot = poly_cheb(np.sqrt(2 / 2**6)) ** 2\n",
-    "print(\"Expected good shots:\", result[\"counts\"].sum() * p_good_shot)"
+    "print(\"Expected good shots:\", df[\"counts\"].sum() * p_good_shot)"
    ]
   },
   {
@@ -447,8 +447,8 @@
     "\n",
     "assert np.isclose(\n",
     "    measured_good_shots,\n",
-    "    result[\"counts\"].sum() * p_good_shot,\n",
-    "    atol=5 * scipy.stats.binom.std(result[\"counts\"].sum(), p_good_shot),\n",
+    "    df[\"counts\"].sum() * p_good_shot,\n",
+    "    atol=5 * scipy.stats.binom.std(df[\"counts\"].sum(), p_good_shot),\n",
     ")"
    ]
   },

--- a/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
+++ b/algorithms/amplitude_amplification_and_estimation/quantum_counting/quantum_counting.ipynb
@@ -271,7 +271,9 @@
    "id": "17",
    "metadata": {},
    "outputs": [],
-   "source": "result = sample(qprog_qpe)"
+   "source": [
+    "df = sample(qprog_qpe)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -305,7 +307,14 @@
      "output_type": "display_data"
     }
    ],
-   "source": "import matplotlib.pyplot as plt\n\nphases_counts = dict(zip(result[\"phase_reg\"], result[\"counts\"]))\nplt.bar(phases_counts.keys(), phases_counts.values(), width=0.1)\nplt.xticks(rotation=90)\nprint(\"phase with max probability: \", max(phases_counts, key=phases_counts.get))"
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "phases_counts = dict(zip(df[\"phase_reg\"], df[\"counts\"]))\n",
+    "plt.bar(phases_counts.keys(), phases_counts.values(), width=0.1)\n",
+    "plt.xticks(rotation=90)\n",
+    "print(\"phase with max probability: \", max(phases_counts, key=phases_counts.get))"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/algorithms/foundational/deutsch_jozsa/deutsch_jozsa.ipynb
+++ b/algorithms/foundational/deutsch_jozsa/deutsch_jozsa.ipynb
@@ -227,8 +227,8 @@
     }
    ],
    "source": [
-    "result_1 = sample(qprog_1)\n",
-    "results_list_1 = result_1[\"x\"].tolist()\n",
+    "df_1 = sample(qprog_1)\n",
+    "results_list_1 = df_1[\"x\"].tolist()\n",
     "post_process_deutsch_jozsa(results_list_1)"
    ]
   },
@@ -327,8 +327,8 @@
     "    constraints=Constraints(max_width=MAX_WIDTH),\n",
     ")\n",
     "\n",
-    "result_2 = sample(qprog_2)\n",
-    "results_list_2 = result_2[\"x\"].tolist()\n",
+    "df_2 = sample(qprog_2)\n",
+    "results_list_2 = df_2[\"x\"].tolist()\n",
     "post_process_deutsch_jozsa(results_list_2)"
    ]
   },

--- a/algorithms/metrology/classical_shadow_tomography.ipynb
+++ b/algorithms/metrology/classical_shadow_tomography.ipynb
@@ -364,13 +364,13 @@
     "    #    list of parameter sets, `sample` returns one DataFrame per element;\n",
     "    #    with `num_shots=1`, each frame has exactly one row whose `qarr`\n",
     "    #    entry is the measured bitstring as a list of ints.\n",
-    "    df_dfs = sample(\n",
+    "    dfs = sample(\n",
     "        qprog,\n",
     "        parameters=param_batch,\n",
     "        num_shots=1,\n",
     "        random_seed=int(np.random.randint(1e6)),\n",
     "    )\n",
-    "    snapshots = [list(df[\"qarr\"].iloc[0]) for df in df_dfs]\n",
+    "    snapshots = [list(df[\"qarr\"].iloc[0]) for df in dfs]\n",
     "\n",
     "    return snapshots, ids"
    ]

--- a/algorithms/metrology/classical_shadow_tomography.ipynb
+++ b/algorithms/metrology/classical_shadow_tomography.ipynb
@@ -364,13 +364,13 @@
     "    #    list of parameter sets, `sample` returns one DataFrame per element;\n",
     "    #    with `num_shots=1`, each frame has exactly one row whose `qarr`\n",
     "    #    entry is the measured bitstring as a list of ints.\n",
-    "    result_dfs = sample(\n",
+    "    df_dfs = sample(\n",
     "        qprog,\n",
     "        parameters=param_batch,\n",
     "        num_shots=1,\n",
     "        random_seed=int(np.random.randint(1e6)),\n",
     "    )\n",
-    "    snapshots = [list(df[\"qarr\"].iloc[0]) for df in result_dfs]\n",
+    "    snapshots = [list(df[\"qarr\"].iloc[0]) for df in df_dfs]\n",
     "\n",
     "    return snapshots, ids"
    ]

--- a/algorithms/number_theory_and_cryptography/discrete_log/discrete_log.ipynb
+++ b/algorithms/number_theory_and_cryptography/discrete_log/discrete_log.ipynb
@@ -498,8 +498,8 @@
     }
    ],
    "source": [
-    "result_Z5 = sample(qprog_Z5)\n",
-    "result_Z5"
+    "df_Z5 = sample(qprog_Z5)\n",
+    "df_Z5"
    ]
   },
   {
@@ -520,7 +520,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for _, res in result_Z5.iterrows():\n",
+    "for _, res in df_Z5.iterrows():\n",
     "    if res[\"beta\"] in [1, 3]:\n",
     "        logarithm = res[\"beta\"] * pow(res[\"alpha\"], -1, 4)\n",
     "        assert logarithm == 3"

--- a/applications/chemistry/protein_folding/protein_folding_with_quantum_walk/qfold.ipynb
+++ b/applications/chemistry/protein_folding/protein_folding_with_quantum_walk/qfold.ipynb
@@ -542,7 +542,7 @@
     }
    ],
    "source": [
-    "result = sample(qprog)"
+    "df = sample(qprog)"
    ]
   },
   {
@@ -630,7 +630,7 @@
     }
    ],
    "source": [
-    "result"
+    "df"
    ]
   },
   {
@@ -648,7 +648,7 @@
     }
    ],
    "source": [
-    "# extract the energy data from search result\n",
+    "# extract the energy data from search df\n",
     "filtered_dict = {k: v for k, v in delta_tbl.items() if k.startswith(\"01\")}\n",
     "print(filtered_dict)"
    ]

--- a/applications/physical_systems/hhl_lanchester/hhl_lanchester.ipynb
+++ b/applications/physical_systems/hhl_lanchester/hhl_lanchester.ipynb
@@ -725,7 +725,7 @@
     }
    ],
    "source": [
-    "result = sample(qprog_hhl_swap, num_shots=NUM_SHOTS)"
+    "df = sample(qprog_hhl_swap, num_shots=NUM_SHOTS)"
    ]
   },
   {
@@ -743,10 +743,10 @@
     }
    ],
    "source": [
-    "indicator_1_test_0_count = result[(result[\"indicator\"] == 1) & (result[\"test\"] == 0)][\n",
+    "indicator_1_test_0_count = df[(df[\"indicator\"] == 1) & (df[\"test\"] == 0)][\n",
     "    \"counts\"\n",
     "].sum()\n",
-    "indicator_1_count = result[result[\"indicator\"] == 1][\"counts\"].sum()\n",
+    "indicator_1_count = df[df[\"indicator\"] == 1][\"counts\"].sum()\n",
     "fidelity_basic = np.sqrt(indicator_1_test_0_count * 2 / indicator_1_count - 1)\n",
     "\n",
     "print(\"Fidelity between basic HHL and classical solutions:\", fidelity_basic)"
@@ -855,7 +855,7 @@
     }
    ],
    "source": [
-    "result = calculate_state_vector(qprog_hhl_basic)"
+    "df = calculate_state_vector(qprog_hhl_basic)"
    ]
   },
   {
@@ -878,7 +878,7 @@
     "\n",
     "\n",
     "filtered_hhl_statevector = dict()\n",
-    "for _, sample in result.iterrows():\n",
+    "for _, sample in df.iterrows():\n",
     "    if sample[\"indicator\"] == 1 and sample[\"rescaled_eig\"] == 0:\n",
     "        filtered_hhl_statevector[\n",
     "            time_index_and_group_value(\n",
@@ -923,7 +923,7 @@
     "plt.plot(np.real(states), np.real(sol_classical_hermitian))\n",
     "plt.xlabel(\"states\")\n",
     "plt.ylabel(\"amplitude\")\n",
-    "plt.legend([\"hhl result\", \"original result\"])\n",
+    "plt.legend([\"hhl df\", \"original df\"])\n",
     "plt.show()"
    ]
   },

--- a/tests/notebooks/test_discrete_log.py
+++ b/tests/notebooks/test_discrete_log.py
@@ -36,8 +36,8 @@ def test_notebook(tb: TestbookNotebookClient) -> None:
 
 
 def _get_result_as_dataframe(tb: TestbookNotebookClient) -> pd.DataFrame:
-    func_res = tb.ref("result_Z5['func_res'].tolist()")
-    probability = tb.ref("result_Z5['probability'].tolist()")
+    func_res = tb.ref("df_Z5['func_res'].tolist()")
+    probability = tb.ref("df_Z5['probability'].tolist()")
     return pd.DataFrame({"func_res": func_res, "probability": probability})
 
 

--- a/tutorials/advanced_tutorials/high_level_modeling_flexible_qpe/high_level_modeling_flexible_qpe.ipynb
+++ b/tutorials/advanced_tutorials/high_level_modeling_flexible_qpe/high_level_modeling_flexible_qpe.ipynb
@@ -385,7 +385,7 @@
     }
    ],
    "source": [
-    "result_1 = sample(qprog_1)"
+    "df_1 = sample(qprog_1)"
    ]
   },
   {
@@ -396,7 +396,7 @@
    "outputs": [],
    "source": [
     "phase_counts = {\n",
-    "    row[\"phase_approx\"] / (2**QPE_SIZE): row[\"counts\"] for _, row in result_1.iterrows()\n",
+    "    row[\"phase_approx\"] / (2**QPE_SIZE): row[\"counts\"] for _, row in df_1.iterrows()\n",
     "}"
    ]
   },
@@ -585,7 +585,7 @@
     }
    ],
    "source": [
-    "result_2 = sample(qprog_2)"
+    "df_2 = sample(qprog_2)"
    ]
   },
   {
@@ -595,7 +595,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_counts = dict(zip(result_2[\"test\"].astype(str), result_2[\"counts\"]))"
+    "test_counts = dict(zip(df_2[\"test\"].astype(str), df_2[\"counts\"]))"
    ]
   },
   {

--- a/tutorials/basic_tutorials/grover_graph_coloring/grover_graph_coloring.ipynb
+++ b/tutorials/basic_tutorials/grover_graph_coloring/grover_graph_coloring.ipynb
@@ -448,8 +448,8 @@
     }
    ],
    "source": [
-    "result = sample(qprog)\n",
-    "result"
+    "df = sample(qprog)\n",
+    "df"
    ]
   },
   {
@@ -499,7 +499,7 @@
     "NUM_SOLUTIONS = 16\n",
     "NUM_VARIABLES = 5\n",
     "solution_list = np.zeros((NUM_SOLUTIONS, NUM_VARIABLES), dtype=int)\n",
-    "for k, row in result.head(NUM_SOLUTIONS).iterrows():\n",
+    "for k, row in df.head(NUM_SOLUTIONS).iterrows():\n",
     "    a = int(row[\"vars.a\"])\n",
     "    b = int(row[\"vars.b\"])\n",
     "    c = int(row[\"vars.c\"])\n",

--- a/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
+++ b/tutorials/basic_tutorials/qmci_pi_estimation/qmci_pi_estimation.ipynb
@@ -326,7 +326,10 @@
    "id": "11",
    "metadata": {},
    "outputs": [],
-   "source": "result = sample(qprog)\nphases_counts = dict(zip(result[\"phase_reg\"], result[\"counts\"]))"
+   "source": [
+    "df = sample(qprog)\n",
+    "phases_counts = dict(zip(df[\"phase_reg\"], df[\"counts\"]))"
+   ]
   },
   {
    "cell_type": "code",

--- a/tutorials/basic_tutorials/quantumwalk_complex_network/quantumwalk_complex_network.ipynb
+++ b/tutorials/basic_tutorials/quantumwalk_complex_network/quantumwalk_complex_network.ipynb
@@ -381,7 +381,7 @@
     }
    ],
    "source": [
-    "result = sample(qprog)"
+    "df = sample(qprog)"
    ]
   },
   {
@@ -428,7 +428,7 @@
     }
    ],
    "source": [
-    "result.plot.bar(x=\"x\", y=\"probability\")"
+    "df.plot.bar(x=\"x\", y=\"probability\")"
    ]
   },
   {
@@ -531,7 +531,7 @@
     "prob_torino_t3_hw = np.array([2567, 2477, 2483, 2473]) / 10000\n",
     "prob_torino_t4_hw = np.array([2269, 2385, 2339, 3007]) / 10000\n",
     "\n",
-    "# Simulator result (ideal)\n",
+    "# Simulator df (ideal)\n",
     "prob_sim_t1 = [0.5, 0.20833333, 0.20833333, 0.08333333]\n",
     "prob_sim_t2 = [0.33333333, 0.28690075, 0.28690075, 0.09286516]\n",
     "prob_sim_t3 = [0.25953183, 0.29985427, 0.29985427, 0.14075964]\n",
@@ -582,7 +582,7 @@
     "prob_torino_t3_hw = np.array([1115, 1186, 1195, 1306, 1250, 1274, 1283, 1391]) / 10000\n",
     "prob_torino_t4_hw = np.array([1347, 1270, 1363, 1351, 1167, 1087, 1201, 1214]) / 10000\n",
     "\n",
-    "# Simulator result (ideal)\n",
+    "# Simulator df (ideal)\n",
     "prob_sim_t1 = [\n",
     "    0.07708333,\n",
     "    0.15,\n",

--- a/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part1.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part1.ipynb
@@ -105,8 +105,8 @@
     "\n",
     "qprog = synthesize(main)  # compile to a gate-level quantum program\n",
     "show(qprog)  # visualize in the Classiq IDE\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -176,8 +176,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -208,8 +208,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -282,8 +282,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog, num_shots=10000)\n",
-    "display(result)"
+    "df = sample(qprog, num_shots=10000)\n",
+    "display(df)"
    ]
   },
   {
@@ -498,8 +498,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -538,8 +538,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -602,8 +602,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -662,8 +662,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -688,8 +688,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -729,8 +729,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog, num_shots=10000)\n",
-    "display(result)"
+    "df = sample(qprog, num_shots=10000)\n",
+    "display(df)"
    ]
   },
   {
@@ -891,8 +891,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -919,8 +919,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -947,8 +947,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   }
  ],

--- a/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
@@ -109,8 +109,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = calculate_state_vector(qprog)\n",
-    "display(result)"
+    "df = calculate_state_vector(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -155,8 +155,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = calculate_state_vector(qprog)\n",
-    "display(result)"
+    "df = calculate_state_vector(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -214,8 +214,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -271,8 +271,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -313,8 +313,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -467,8 +467,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -509,8 +509,8 @@
     "qprog = synthesize(main)\n",
     "show(qprog)\n",
     "\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -652,8 +652,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = calculate_state_vector(qprog)\n",
-    "display(result)"
+    "df = calculate_state_vector(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -686,8 +686,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = calculate_state_vector(qprog)\n",
-    "display(result)"
+    "df = calculate_state_vector(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -717,8 +717,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -756,8 +756,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -792,8 +792,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -833,8 +833,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -859,8 +859,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = observe(qprog, Pauli.X(0) + Pauli.X(1))\n",
-    "print(result)"
+    "df = observe(qprog, Pauli.X(0) + Pauli.X(1))\n",
+    "print(df)"
    ]
   },
   {
@@ -898,8 +898,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {
@@ -928,8 +928,8 @@
     "\n",
     "\n",
     "qprog = synthesize(main)\n",
-    "result = sample(qprog)\n",
-    "display(result)"
+    "df = sample(qprog)\n",
+    "display(df)"
    ]
   },
   {

--- a/tutorials/workshops/oracle_workshop/oracles_workshop.ipynb
+++ b/tutorials/workshops/oracle_workshop/oracles_workshop.ipynb
@@ -933,8 +933,8 @@
     "        )\n",
     "\n",
     "\n",
-    "result = sample(qprog_deutsch_jozsa)\n",
-    "results_list = result[\"x\"].tolist()\n",
+    "df = sample(qprog_deutsch_jozsa)\n",
+    "results_list = df[\"x\"].tolist()\n",
     "post_process_deutsch_jozsa(results_list)"
    ]
   },


### PR DESCRIPTION
## Summary
- `sample()` returns `DataFrame`, so use `df` as the idiomatic variable name
- Renames `result` → `df`, `result_1` → `df_1`, `result_2` → `df_2`, etc.

## Changes
15 notebooks updated.

## Test plan
- [ ] Run notebook tests for modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)