### PR TITLE
Pin isort to <9 in nbqa-isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
     hooks:
       - id: nbqa-isort
         name: format    notebook isort
+        additional_dependencies:
+          - isort<9
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- isort 9.0.0 (released 2026-08-26) broke `python -m isort` invocation with `No code object available for isort.__main__; 'isort' is a package and cannot be directly executed`, which the `nbqa-isort` pre-commit hook relies on.
- The hook doesn't pin an isort version, so it was pulling latest and failing the `lint` CI job on unrelated PRs (e.g. #1718).
- Pin `isort<9` via `additional_dependencies` on the hook to unblock lint.

## Test plan
- [x] Ran `pre-commit run nbqa-isort --all-files` locally — passes with the pin (previously failed with the same error seen in CI).