### PR TITLE
fix(deps): pin nlft-qsp<2.0.0 to fix broken import

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -9,7 +9,7 @@ torchvision
 galois
 cvxpy
 pyqsp
-nlft-qsp
+nlft-qsp<2.0.0
 jsonpickle
 tensorboard
 qiskit


### PR DESCRIPTION
## Summary
- Pin `nlft-qsp<2.0.0` in test requirements to work around a packaging bug

## Problem
`nlft-qsp 2.0.0` (released 2026-08-17) is completely broken - the wheel is missing `solvers/completion.py` but `solvers/__init__.py` tries to import from it:

```
ModuleNotFoundError: No module named 'nlft_qsp.solvers.completion'
```

This breaks any notebook that uses `classiq.applications.qsp`, including `qsvt_fixed_point_amplitude_amplification`.

## Fix
Pin to `<2.0.0` to use the working 1.0.4 version until upstream fixes the package.

## Test plan
- [x] Verified `nlft-qsp 2.0.0` fails on bare `import nlft_qsp`
- [ ] CI should pass with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)