### PR TITLE
Replace deprecated apply_phase_table with assign_phase_table

### DIFF
--- a/applications/CFD/QLS_for_hybrid_solvers/pauli_be.py
+++ b/applications/CFD/QLS_for_hybrid_solvers/pauli_be.py
@@ -5,7 +5,6 @@ from openfermion.utils.operator_utils import count_qubits
 from sympy import fwht
 from classiq import *
 import numpy as np
-from classiq.open_library.functions.state_preparation import apply_phase_table
 
 
 # TODO: remove after bug fix
@@ -261,7 +260,7 @@ def lcu_paulis_graycode(terms: list[SparsePauliTerm], data: QArray, block: QArra
         for i in range(n_qubits):
             multiplex_ra(0, 1, table_z[i, :], block, data[i])
             multiplex_ra(1, 0, table_y[i, :], block, data[i])
-        apply_phase_table(
+        assign_phase_table(
             [p1 - p2 for p1, p2 in zip(hamiltonian_coeffs, accumulated_phase)], block
         )
 


### PR DESCRIPTION
## Summary
- Replace deprecated `apply_phase_table` from `classiq.open_library.functions.state_preparation` with the builtin `assign_phase_table`
- Remove the now-unnecessary import

## Test plan
- [ ] Verify the QLS_for_hybrid_solvers notebook still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)