### PR TITLE
conventions: detect the execution-API migration as a signal family

### DIFF
--- a/.internal/conventions/STATUS.md
+++ b/.internal/conventions/STATUS.md
@@ -8,11 +8,26 @@ Scope: unless noted, a point was applied to the **`main` folders** only
 (`algorithms/`, `applications/`, `tutorials/`, ~163 notebooks). `community/`,
 `functions/`, and `benchmarking/` are reached by re-running the same agent/tool.
 
-> **Parked as _old_ — execution-API refactor.** `execution_interface`,
-> `result_value`, and `result_var` were shaped _before_ the execution API was
-> refactored, which superseded them. They stay in the report marked _old_ (for
-> the record), not as active work — `result_value` is still auto-enforced by the
-> pre-commit hook.
+> **`execution_interface` is now the active detector for the execution-API
+> migration.** It was reshaped (Sep 2026) into an _umbrella_ point over a family
+> of sub-signals (`points/_exec_signals.py`) — `execute(`, nested
+> `ExecutionPreferences(`, `ExecutionSession`, `parsed_counts`, `.dataframe`,
+> `set_*_preferences`, `.estimate(`, `.minimize(`, `batch_*`. The report shows the
+> umbrella score plus one indented sub-row per family (each with its own fraction
+> and %), so per-pattern scope is visible at a glance. Target interface follows
+> PR #1643 + the migration ticket: free `sample()` / `observe()` (a flat
+> `ExecutionSession` only for deliberate multi-call reuse), `observe` over
+> `.estimate`, `variational_minimize` over `.minimize`, no `batch_*`, and a
+> DataFrame-shaped result. **The ticket's `calculate_statevector` is a typo** —
+> the real SDK function is `calculate_state_vector` (verified against classiq
+> 1.27.0), which is current/correct, so it is deliberately _not_ a signal.
+>
+> **`result_value` / `result_var` stay parked as _old_.** They were shaped before
+> the exec-API refactor. `result_value` is still auto-enforced by the hook. The
+> result-variable naming they encode is being _superseded_ by a return-type split:
+> DataFrame results → `df` / `df_1` / `df_something` (prefix form, never
+> `something_df`); non-DataFrame → `result` / `job` (same prefix rule). That split
+> will land as its own point later.
 >
 > **`intro_opener` was dropped** — we decided not to pursue the "This notebook …"
 > opener convention. It stays in the report marked _dropped_.
@@ -27,23 +42,23 @@ Scope: unless noted, a point was applied to the **`main` folders** only
 
 Rows below follow the report's own order (skeleton → prose → code → parked).
 
-| Point                 | Convention                                            | Status                                                     | Resume / extend with                                                                |
-| --------------------- | ----------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `opens_h1`            | opens with an H1 title                                | ✅ done · **enforced** (check — a title can't be invented) | hook `pre_commit_tools/notebook_uniformity.py`                                      |
-| `single_h1`           | exactly one H1 (the title)                            | ✅ done · **enforced** (auto-fix)                          | `point_single_h1.fix()`; `one_off_fixes/fix_single_h1.py`                           |
-| `headings`            | heading hierarchy (levels & nesting)                  | ✅ main pass done (see report for residuals)               | agent `notebook-heading-hierarchy` + `tools/heading_outline.py`, `heading_stats.py` |
-| `title_case`          | headings in Title Case                                | ⛔ open (agent doc added)                                  | agent `notebook-title-case` + `tools/heading_outline.py`                            |
-| `math`                | display → `$$`; unicode math → LaTeX                  | ⏸ on hold by design                                        | agent `notebook-math-notation` + `tools/md_replace.py`, `math_lint.py`              |
-| `unicode`             | stray unicode typography → ASCII/LaTeX                | ✅ main pass done (see report for residuals)               | agent `notebook-unicode-cleanup` + `tools/nonascii.py`, `unicode_audit.py`          |
-| `references`          | `## References` (plural)                              | ✅ done · **enforced** (auto-fix)                          | hook                                                                                |
-| `def_main`            | builds a circuit (`def main` / known wrapper)         | 🔎 investigate-only; comparison notebooks are exceptions   | `report.py --rule def_main`                                                         |
-| `synthesize_main`     | `synthesize(main)`, not `create_model()+synthesize()` | 🟡 partial — trivial cases scripted; rest manual           | `one_off_fixes/collapse_synthesize.py`                                              |
-| `qprog_var`           | synth-output var `qprog` / `qprog_<suffix>`           | ✅ done                                                    | agent `notebook-variable-names` + `tools/rename_var.py`                             |
-| `show`                | `show(qprog)`, not `qprog.show()`                     | ✅ done · **enforced** (auto-fix)                          | hook                                                                                |
-| `execution_interface` | new execution-API usage                               | 🗄 old — superseded by the exec-API refactor                | `report.py --rule execution_interface --list`                                       |
-| `result_value`        | `.result_value()`, not `.result()[0].value`           | 🗄 old — superseded (still hook-enforced)                   | hook; `one_off_fixes/fix_result_value.py`                                           |
-| `result_var`          | exec-result var `result` / `job` (by type)            | 🗄 old — superseded by the exec-API refactor                | agent `notebook-variable-names` + `tools/rename_var.py`                             |
-| `intro_opener`        | "This notebook …" opener                              | 🗄 dropped — decided not to pursue                          | agent `notebook-intro-opener` + `tools/md_replace.py`                               |
+| Point                 | Convention                                              | Status                                                     | Resume / extend with                                                                   |
+| --------------------- | ------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `opens_h1`            | opens with an H1 title                                  | ✅ done · **enforced** (check — a title can't be invented) | hook `pre_commit_tools/notebook_uniformity.py`                                         |
+| `single_h1`           | exactly one H1 (the title)                              | ✅ done · **enforced** (auto-fix)                          | `point_single_h1.fix()`; `one_off_fixes/fix_single_h1.py`                              |
+| `headings`            | heading hierarchy (levels & nesting)                    | ✅ main pass done (see report for residuals)               | agent `notebook-heading-hierarchy` + `tools/heading_outline.py`, `heading_stats.py`    |
+| `title_case`          | headings in Title Case                                  | ⛔ open (agent doc added)                                  | agent `notebook-title-case` + `tools/heading_outline.py`                               |
+| `math`                | display → `$$`; unicode math → LaTeX                    | ⏸ on hold by design                                        | agent `notebook-math-notation` + `tools/md_replace.py`, `math_lint.py`                 |
+| `unicode`             | stray unicode typography → ASCII/LaTeX                  | ✅ main pass done (see report for residuals)               | agent `notebook-unicode-cleanup` + `tools/nonascii.py`, `unicode_audit.py`             |
+| `references`          | `## References` (plural)                                | ✅ done · **enforced** (auto-fix)                          | hook                                                                                   |
+| `def_main`            | builds a circuit (`def main` / known wrapper)           | 🔎 investigate-only; comparison notebooks are exceptions   | `report.py --rule def_main`                                                            |
+| `synthesize_main`     | `synthesize(main)`, not `create_model()+synthesize()`   | 🟡 partial — trivial cases scripted; rest manual           | `one_off_fixes/collapse_synthesize.py`                                                 |
+| `qprog_var`           | synth-output var `qprog` / `qprog_<suffix>`             | ✅ done                                                    | agent `notebook-variable-names` + `tools/rename_var.py`                                |
+| `show`                | `show(qprog)`, not `qprog.show()`                       | ✅ done · **enforced** (auto-fix)                          | hook                                                                                   |
+| `execution_interface` | new execution-API usage (umbrella over a signal family) | 🟢 active — 54/163 main still on old API (detect done)     | `report.py --rule execution_interface [--cards]`; signals in `points/_exec_signals.py` |
+| `result_value`        | `.result_value()`, not `.result()[0].value`             | 🗄 old — superseded (still hook-enforced)                   | hook; `one_off_fixes/fix_result_value.py`                                              |
+| `result_var`          | exec-result var `result` / `job` (by type)              | 🗄 old — superseded by the exec-API refactor                | agent `notebook-variable-names` + `tools/rename_var.py`                                |
+| `intro_opener`        | "This notebook …" opener                                | 🗄 dropped — decided not to pursue                          | agent `notebook-intro-opener` + `tools/md_replace.py`                                  |
 
 Not a point: **sidecar files** (`.qmod` / `.synth` / `.metadata`) — out of scope here.
 

--- a/.internal/conventions/agents/notebook-execution-api.md
+++ b/.internal/conventions/agents/notebook-execution-api.md
@@ -96,6 +96,31 @@ count_0 = df[df["output_var"] == 0]["counts"].sum()
 total = df["counts"].sum()
 ```
 
+### 5b. estimate / minimize migration
+
+`observe` replaces `estimate`; `variational_minimize` replaces `minimize`.
+
+```python
+# OLD: standalone estimate on a session
+with ExecutionSession(qprog) as es:
+    value = es.estimate(hamiltonian).value
+
+# NEW: free observe() returns the float directly (no .value)
+value = observe(qprog, hamiltonian)
+
+# with parameters
+value = observe(qprog, hamiltonian, parameters={"params": p})
+```
+
+When the session is **kept** (in a loop — see rule 2), rename the methods in
+place; the signatures are unchanged:
+
+- `es.estimate(...)` → `es.observe(...)`
+- `es.minimize(...)` → `es.variational_minimize(...)`
+
+Note: SciPy's `optimize.minimize(...)` is unrelated — leave it alone. Only a
+session's `.minimize(` is migrated.
+
 ### 6. Imports to remove
 
 Remove these imports when no longer used:
@@ -124,6 +149,9 @@ Rename inconsistent shot count variables to `NUM_SHOTS`:
    - `ExecutionSession` usage
    - `set_execution_preferences()` calls
    - `ExecutionPreferences` imports
+   - `.estimate(` / `.minimize(` on a session (not SciPy's `optimize.minimize`)
+   - `batch_sample` / `batch_estimate` / `batch_observe` (pass a list of params
+     to the regular method instead)
    - Result access patterns (`parsed_counts`, `.dataframe`, `.counts`)
 
 2. **Plan** the changes:

--- a/.internal/conventions/points/_exec_signals.py
+++ b/.internal/conventions/points/_exec_signals.py
@@ -1,0 +1,77 @@
+"""The execution-API migration, split into its family of signals.
+
+Each entry maps a family name to a `detect(nb) -> list[str]` over a notebook's
+code (empty list == clean). The `execution_interface` point unions these; the
+report renders one sub-row per family so we can see per-pattern scope.
+
+Target interface (per PR #1643 + the migration ticket):
+- free `sample()` / `observe()` instead of `execute()` and instead of an
+  `ExecutionSession` context manager for one-shot calls (a session is still fine
+  when you deliberately reuse it across many calls);
+- no nested `ExecutionPreferences(...)` / `set_*_preferences(...)` — pass
+  `num_shots` / backend directly;
+- `observe` not `.estimate`, `variational_minimize` not `.minimize`;
+- no `batch_*` — the regular methods take a list of params;
+- the sample result *is* the DataFrame: `result["x"]` and `.iterrows()`,
+  not `.dataframe["x"]` / `.parsed_counts`.
+
+NOTE: the ticket's `calculate_statevector` is a typo — the real SDK function is
+`calculate_state_vector` (verified against classiq 1.27.0), which is current and
+correct, so it is deliberately NOT a signal here.
+"""
+
+import re
+
+from ._model import Notebook
+
+# --- individual family detectors -----------------------------------------
+
+
+def _finder(pattern: str):
+    """A detector that returns every match of `pattern` in the code."""
+    rx = re.compile(pattern)
+    return lambda nb: [m.group(0) for m in rx.finditer(nb.code)]
+
+
+_EXECUTE = re.compile(r"(?<![\w.])execute\s*\(")
+
+
+def _execute(nb: Notebook) -> list[str]:
+    """Old free `execute(...)`, excluding a notebook's own `def execute(` helper."""
+    out = []
+    for m in _EXECUTE.finditer(nb.code):
+        if not nb.code[max(0, m.start() - 4) : m.start()].endswith("def "):
+            out.append(m.group(0))
+    return out
+
+
+_MINIMIZE = re.compile(r"(\w+)\.minimize\s*\(")
+
+
+def _minimize(nb: Notebook) -> list[str]:
+    """`.minimize(` on a session, but not SciPy's `optimize.minimize(`."""
+    return [m.group(0) for m in _MINIMIZE.finditer(nb.code) if m.group(1) != "optimize"]
+
+
+# --- the family, in migration-priority order -----------------------------
+
+SIGNALS = {
+    # structural — reshape cells (agent territory)
+    "execute(": _execute,
+    "ExecutionPreferences(": _finder(r"\bExecutionPreferences\s*\("),
+    "ExecutionSession": _finder(r"\bExecutionSession\b"),
+    "parsed_counts": _finder(r"\bparsed_counts\b"),
+    ".dataframe": _finder(r"\.dataframe\b"),
+    # mechanical — localized renames / removals (scriptable)
+    "set_*_preferences": _finder(
+        r"\bset_(?:execution|quantum_program_execution)_preferences\b"
+    ),
+    ".estimate(": _finder(r"\.estimate\s*\("),
+    ".minimize(": _minimize,
+    "batch_*": _finder(r"\bbatch_(?:sample|estimate|observe)\b"),
+}
+
+
+def detect(nb: Notebook) -> list[str]:
+    """Union of every family — the offenders for the umbrella point."""
+    return [hit for det in SIGNALS.values() for hit in det(nb)]

--- a/.internal/conventions/points/_model.py
+++ b/.internal/conventions/points/_model.py
@@ -67,6 +67,12 @@ class Point:
     status: str = "active"  # lifecycle: "active" | "outdated" | "dropped"
     exceptions: tuple = field(default_factory=tuple)  # (path_fragment, reason)
 
+    # Optional per-family breakdown: name -> detect(nb) for a sub-signal. When set,
+    # the point's own detect() is the union of these, and the report renders one
+    # indented sub-row (with its own fraction and %) per family. Used by
+    # `execution_interface`, whose migration is really a family of signals.
+    subsignals: dict = field(default_factory=dict)
+
     def tags(self) -> list[str]:
         if not self.static:
             return ["agent", "enforced"] if self.enforced else ["agent"]

--- a/.internal/conventions/points/point_execution_interface.py
+++ b/.internal/conventions/points/point_execution_interface.py
@@ -1,28 +1,29 @@
-"""Use the new execution interface, not the old execute() call.
+"""Use the new execution interface, not the old one.
 
-The SDK is moving from `execute(qprog).result_value()` to the ExecutionSession
-API (`es.sample()` / `.run()` / `.estimate()`) and `calculate_state_vector()`.
-This point tracks that migration; it supersedes `result_value` over time.
+This is not a single rule but a *family* of signals — the SDK moved from
+`execute(qprog).result_value()` and nested `ExecutionPreferences` to free
+`sample()` / `observe()` (and a flat `ExecutionSession` only for deliberate
+multi-call reuse), plus a DataFrame-shaped result. The individual signals live
+in `_exec_signals.py`; this point unions them and the report shows a per-family
+breakdown underneath it.
 """
 
-import re
-
+from . import _exec_signals
 from ._model import Notebook, Point
-
-_OLD_EXECUTE = re.compile(r"(?<![\w.])execute\(")
 
 
 def detect(nb: Notebook) -> list[str]:
-    return _OLD_EXECUTE.findall(nb.code)
+    return _exec_signals.detect(nb)
 
 
 POINT = Point(
     title="execution_interface",
-    detail="execute(qprog).result_value()  ->  ExecutionSession / calculate_state_vector",
-    description="Use the new execution interface (ExecutionSession, calculate_state_vector), "
-    "not execute(). Tracks the ongoing SDK migration.",
+    detail="execute() / ExecutionPreferences / .estimate / batch_*  ->  sample() / observe() / variational_minimize",
+    description="Use the new execution interface: free sample()/observe(), no nested "
+    "ExecutionPreferences, observe not .estimate, variational_minimize not .minimize, "
+    "no batch_*, and a DataFrame-shaped result (no .parsed_counts / .dataframe).",
     static=True,
     detect=detect,
-    fix=None,  # migration reshapes cells; done by the team's migration, not a regex
-    status="outdated",
+    fix=None,  # migration reshapes cells; handled per-family (script or agent), not one regex
+    subsignals=_exec_signals.SIGNALS,
 )

--- a/.internal/conventions/report.py
+++ b/.internal/conventions/report.py
@@ -18,7 +18,7 @@ import os
 import subprocess
 import sys
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 HERE = Path(__file__).parent
@@ -41,9 +41,9 @@ ORDER = [
     # prose & notation
     "math", "unicode", "references",
     # code & circuit
-    "def_main", "synthesize_main", "qprog_var", "show",
+    "def_main", "synthesize_main", "qprog_var", "show", "execution_interface",
     # parked — superseded by the execution-API refactor
-    "execution_interface", "result_value", "result_var",
+    "result_value", "result_var",
     # parked — decided against
     "intro_opener",
 ]  # fmt: skip
@@ -107,46 +107,88 @@ def _active(point: Point) -> bool:
 # --- analysis -------------------------------------------------------------
 
 
+# --- counts shared by a point and its sub-signals -------------------------
+
+Counts = dict[str, tuple[int, int]]  # group -> (conforming, total)
+
+
+def _ok(counts: Counts) -> int:
+    return sum(ok for ok, _ in counts.values())
+
+
+def _total(counts: Counts) -> int:
+    return sum(total for _, total in counts.values())
+
+
+def _pct(counts: Counts) -> int:
+    # floor, never round up: 100% must mean truly complete, not 216/217
+    return 100 * _ok(counts) // _total(counts) if _total(counts) else 100
+
+
+def _counts_by_group(bad: set[str], nbs: list[Notebook]) -> Counts:
+    """(conforming, total) per group, given the set of offending paths."""
+    counts = {}
+    for g in GROUPS:
+        group = [nb for nb in nbs if _group(nb.rel) == g]
+        counts[g] = (sum(nb.rel not in bad for nb in group), len(group))
+    return counts
+
+
+@dataclass
+class SubResult:
+    name: str  # a family signal under an umbrella point (e.g. "execute(")
+    counts: Counts
+
+    @property
+    def pct(self) -> int:
+        return _pct(self.counts)
+
+
 @dataclass
 class PointResult:
     point: Point
     offenders: list[Notebook]  # notebooks that violate the point (exceptions excluded)
-    counts: dict[str, tuple[int, int]]  # group -> (conforming, total)
+    counts: Counts
+    subs: list[SubResult] = field(default_factory=list)  # per-family breakdown, if any
 
     @property
     def ok(self) -> int:
-        return sum(ok for ok, _ in self.counts.values())
+        return _ok(self.counts)
 
     @property
     def total(self) -> int:
-        return sum(total for _, total in self.counts.values())
+        return _total(self.counts)
 
     @property
     def pct(self) -> int:
-        # floor, never round up: 100% must mean truly complete, not 216/217
-        return 100 * self.ok // self.total if self.total else 100
+        return _pct(self.counts)
 
     @property
     def conforms(self) -> bool:
         return not self.offenders
 
 
+def _excepted(point: Point, nb: Notebook) -> bool:
+    return any(frag in nb.rel for frag, _ in point.exceptions)
+
+
 def _offenders(point: Point, nbs: list[Notebook]) -> list[Notebook]:
-    return [
-        nb
-        for nb in nbs
-        if point.detect(nb) and not any(frag in nb.rel for frag, _ in point.exceptions)
-    ]
+    return [nb for nb in nbs if point.detect(nb) and not _excepted(point, nb)]
 
 
 def evaluate(point: Point, nbs: list[Notebook]) -> PointResult:
     offenders = _offenders(point, nbs)
-    bad = {nb.rel for nb in offenders}
-    counts = {}
-    for g in GROUPS:
-        group = [nb for nb in nbs if _group(nb.rel) == g]
-        counts[g] = (sum(nb.rel not in bad for nb in group), len(group))
-    return PointResult(point=point, offenders=offenders, counts=counts)
+    counts = _counts_by_group({nb.rel for nb in offenders}, nbs)
+    subs = [
+        SubResult(
+            name,
+            _counts_by_group(
+                {nb.rel for nb in nbs if det(nb) and not _excepted(point, nb)}, nbs
+            ),
+        )
+        for name, det in point.subsignals.items()
+    ]
+    return PointResult(point=point, offenders=offenders, counts=counts, subs=subs)
 
 
 def _is_approx(point: Point) -> bool:
@@ -280,6 +322,11 @@ def render_cards(
         split = " · ".join(f"{g} {ok}/{tot}" for g, (ok, tot) in r.counts.items())
         pct = Ansi.paint(f"{r.pct}%", _pct_color(r.pct))
         print(f"      {r.ok}/{r.total} ({pct})    {Ansi.paint(split, Ansi.DIM)}")
+        for s in r.subs:  # per-family breakdown, each with its own frac + %
+            name = Ansi.paint(f"{s.name:22}", Ansi.DIM)
+            spct = Ansi.paint(f"{s.pct}%", _pct_color(s.pct))
+            frac = f"{_ok(s.counts)}/{_total(s.counts)}"
+            print(f"        {name} {frac:>7} ({spct})")
         if show_files is not False and r.offenders:  # False hides; None caps; True all
             _print_paths(r.offenders, " " * 9, cap=None if show_files else PREVIEW)
 
@@ -297,9 +344,23 @@ def _table_row(r: PointResult) -> tuple[tuple, list[str | None]]:
     return cells, colors
 
 
+def _sub_row(s: SubResult) -> tuple[tuple, list[str | None]]:
+    fracs = tuple(_frac(s.counts[g]) for g in GROUPS) + (
+        _frac((_ok(s.counts), _total(s.counts))),
+    )
+    cells = ("", f"  {s.name}", *fracs, f"{s.pct}%", "")
+    colors: list[str | None] = [Ansi.DIM] * len(cells)
+    colors[6] = _pct_color(s.pct)  # keep the % readable even in a dimmed sub-row
+    return cells, colors
+
+
 def render_table(results: list[PointResult], show_files: bool | None) -> None:
     head = ("", "point", "main", "community", "other", "all", "%", "kind")
-    built = [_table_row(r) for r in results]
+    built = []
+    for r in results:
+        built.append(_table_row(r))
+        if _active(r.point):  # indented per-family sub-rows, each with its own frac + %
+            built.extend(_sub_row(s) for s in r.subs)
     rows = [cells for cells, _ in built]
     widths = [max(map(len, col)) for col in zip(head, *rows)]
 


### PR DESCRIPTION
## What

Turns the parked, `execute()`-only `execution_interface` convention point into an **active umbrella detector** for the whole execution-API migration, so `report.py` measures per-pattern scope.

Each family is a sub-signal (`points/_exec_signals.py`): `execute(`, nested `ExecutionPreferences(`, `ExecutionSession`, `parsed_counts`, `.dataframe`, `set_*_preferences`, `.estimate(`, `.minimize(`, `batch_*`. The report shows the umbrella score plus one indented sub-row per family, each with its own fraction and `%`.

```
→  execution_interface      109/163  3/18   38/38  150/219  68%
     execute(               156/163  6/18   38/38  200/219  91%
     ExecutionPreferences(  124/163  6/18   38/38  168/219  76%
     ExecutionSession       131/163  14/18  38/38  183/219  83%
     ... (one row per family)
```

## Scope this reveals

Verified on `origin/main` with classiq 1.27.0: **54/163 main** notebooks still on the old API, 15/18 community, and `other/` (functions, benchmarking) already clean.

## Notes

- The migration ticket's `calculate_statevector` is a **typo** — the real SDK function is `calculate_state_vector` (underscores), which is current and correct, so it is deliberately **not** a signal (it would have flagged 27 good notebooks).
- This PR is **detection only** — no notebook edits. The actual fixes land as a PR per family, on top of this.

## Files

- `points/_exec_signals.py` (new) — family detectors + union
- `points/point_execution_interface.py` — umbrella point, now active
- `points/_model.py` — `Point.subsignals` field
- `report.py` — per-family sub-row rendering (table + cards)
- `STATUS.md` — reflect the active detector + the return-type naming split

🤖 Generated with [Claude Code](https://claude.com/claude-code)