### PR TITLE
fix(notebooks): normalize stray unicode in Qmod tutorials (unicode -> 100%)

### DIFF
--- a/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part1.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part1.ipynb
@@ -5,7 +5,7 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Qmod Tutorial — Part I\n",
+    "# Qmod Tutorial - Part I\n",
     "\n",
     "Welcome to the Qmod tutorial! **Qmod** is Classiq's quantum programming language,\n",
     "embedded in Python (Qmod also has standalone syntax which we will not cover here). Across two notebooks you will build up the core toolkit for designing\n",
@@ -23,9 +23,9 @@
     "\n",
     "Each section has a short concept explanation followed by an exercise. Complete the code where\n",
     "marked with `# TODO`, then synthesize and run it. **All solutions are\n",
-    "collected at the end of the notebook** — try each exercise before peeking.\n",
+    "collected at the end of the notebook** - try each exercise before peeking.\n",
     "\n",
-    "**Part II** then builds on these foundations with six more concepts — the statements and operators used to express real quantum algorithms."
+    "**Part II** then builds on these foundations with six more concepts - the statements and operators used to express real quantum algorithms."
    ]
   },
   {
@@ -59,10 +59,10 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "## Warmup — Quantum Functions and `main`\n",
+    "## Warmup - Quantum Functions and `main`\n",
     "\n",
     "The `@qfunc` decorator designates a\n",
-    "[quantum function](https://docs.classiq.io/qmod-reference/language-reference/functions) — a\n",
+    "[quantum function](https://docs.classiq.io/qmod-reference/language-reference/functions) - a\n",
     "function that applies operations to quantum objects.\n",
     "\n",
     "The **entry point** of a quantum program, that is, the quantum function synthesized into an executable, must be named `main`. The quantum parameters of `main` are designated with the `Output`-modifier, and they are measured when the program is executed. Function `main` can call other quantum functions.\n",
@@ -81,7 +81,7 @@
    "source": [
     "**Exercise:** *No coding required.* The cell below prepares and samples a **Bell state**, one of\n",
     "the most fundamental entangled states, $\\frac{1}{\\sqrt{2}}(|00\\rangle + |11\\rangle)$. Just run\n",
-    "it and observe the synthesis → visualization → execution flow."
+    "it and observe the synthesis -> visualization -> execution flow."
    ]
   },
   {
@@ -114,7 +114,7 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "> **Expected result:** roughly 50% of the samples are the bit vector `00` and 50% are `11` —\n",
+    "> **Expected result:** roughly 50% of the samples are the bit vector `00` and 50% are `11` -\n",
     "> the two qubits are perfectly correlated."
    ]
   },
@@ -125,22 +125,22 @@
    "source": [
     "## 1. Quantum Variables and Quantum Types\n",
     "\n",
-    "A quantum **variable** is a reference to a **quantum object** — the quantum state stored on one or more specific qubits. Its\n",
+    "A quantum **variable** is a reference to a **quantum object** - the quantum state stored on one or more specific qubits. Its\n",
     "[type](https://docs.classiq.io/qmod-reference/language-reference/quantum-types) tells the\n",
     "compiler how to interpret and operate on those qubits:\n",
     "\n",
-    "- `QBit` — a single qubit.\n",
-    "- `QNum` — a number, supporting arithmetic and comparisons. You can specify its size, signedness,\n",
+    "- `QBit` - a single qubit.\n",
+    "- `QNum` - a number, supporting arithmetic and comparisons. You can specify its size, signedness,\n",
     "  and fractional digits (e.g. `QNum[3, SIGNED, 0]`).\n",
-    "- `QArray` — an indexable array (e.g. `my_qarr[i]`) of elements of any quantum type; `QArray[QBit]` is the\n",
+    "- `QArray` - an indexable array (e.g. `my_qarr[i]`) of elements of any quantum type; `QArray[QBit]` is the\n",
     "  most common.\n",
-    "- `QStruct` — a struct of named fields (e.g. `my_qstruct.f`); we'll return to structs later.\n",
+    "- `QStruct` - a struct of named fields (e.g. `my_qstruct.f`); we'll return to structs later.\n",
     "\n",
-    "Size and length are optional — leave them unspecified (e.g. `QNum`, `QArray[QBit]`) and the\n",
+    "Size and length are optional - leave them unspecified (e.g. `QNum`, `QArray[QBit]`) and the\n",
     "compiler infers them when the variable is initialized.\n",
     "\n",
-    "Function arguments are automatically **cast** between quantum types of the same size — e.g. between\n",
-    "`QArray[QBit]` and `QNum` — so the same function can operate on either."
+    "Function arguments are automatically **cast** between quantum types of the same size - e.g. between\n",
+    "`QArray[QBit]` and `QNum` - so the same function can operate on either."
    ]
   },
   {
@@ -227,7 +227,7 @@
    "source": [
     "## 2. Output Parameters and State-Preparation Functions\n",
     "\n",
-    "By default, a quantum parameter refers to an object passed *into* the function and back *out* to the caller — it is already initialized when entering the function. Declaring a parameter `Output` makes it **output-only**: it starts uninitialized and must be initialized inside the function.\n",
+    "By default, a quantum parameter refers to an object passed *into* the function and back *out* to the caller - it is already initialized when entering the function. Declaring a parameter `Output` makes it **output-only**: it starts uninitialized and must be initialized inside the function.\n",
     "\n",
     "A variable is initialized by:\n",
     "\n",
@@ -237,12 +237,12 @@
     "\n",
     "See also [Quantum variables](https://docs.classiq.io/qmod-reference/language-reference/quantum-variables).\n",
     "\n",
-    "> **Note:** All of `main`'s parameters must be `Output` — as the entry point, there is nowhere they could have been initialized beforehand.\n",
+    "> **Note:** All of `main`'s parameters must be `Output` - as the entry point, there is nowhere they could have been initialized beforehand.\n",
     "\n",
     "Classiq provides built-in [state-preparation functions](https://docs.classiq.io/qmod-reference/library-reference/core-library-functions/prepare_state_and_amplitudes/prepare_state_and_amplitudes/). Two closely related ones:\n",
     "\n",
-    "- `prepare_state(probabilities, bound, out)` — allocates a fresh object and prepares it in a state whose measurement distribution matches `probabilities` (**out-of-place**).\n",
-    "- `inplace_prepare_state(probabilities, bound, target)` — applies the same preparation to an **already-allocated** object `target` (**in-place**), assumed to be in the $|0\\rangle$ state.\n",
+    "- `prepare_state(probabilities, bound, out)` - allocates a fresh object and prepares it in a state whose measurement distribution matches `probabilities` (**out-of-place**).\n",
+    "- `inplace_prepare_state(probabilities, bound, target)` - applies the same preparation to an **already-allocated** object `target` (**in-place**), assumed to be in the $|0\\rangle$ state.\n",
     "\n",
     "(In both cases, `bound` determines the maximum allowed error.)"
    ]
@@ -291,7 +291,7 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "> **Expected result:** The probability of measuring `000` on both `a` and `b` is the highest — $0.3 \\times 0.3$, and the probability of measuring `111` on both should be the lowest — $0.02 \\times 0.02$."
+    "> **Expected result:** The probability of measuring `000` on both `a` and `b` is the highest - $0.3 \\times 0.3$, and the probability of measuring `111` on both should be the lowest - $0.02 \\times 0.02$."
    ]
   },
   {
@@ -299,7 +299,7 @@
    "id": "18",
    "metadata": {},
    "source": [
-    "**Exercise B:** The cell below fails — the variable `q` is never initialized. Run it to see the\n",
+    "**Exercise B:** The cell below fails - the variable `q` is never initialized. Run it to see the\n",
     "error, then fix it such that `prep` is responsible for initializing `q`."
    ]
   },
@@ -330,7 +330,7 @@
    "cell_type": "markdown",
    "id": "20",
    "metadata": {},
-   "source": "## 3. Classical Parameters\n\nQmod functions can take **classical** parameters, in addition to quantum parameters. You already used them in Exercise A of §2 — the parameters of `prepare_state()`. Classical parameters are declared with Qmod [classical types](https://docs.classiq.io/qmod-reference/language-reference/classical-types) — `CInt`, `CReal`, `CArray`, etc. Classical parameters can be used in Qmod expressions and statements. The size of quantum variables (e.g. `my_qnum.size`) and the length of arrays (e.g. `my_qarr.len`) are also classical expressions in Qmod.\n\nWhen `main` has a classical parameter, its value is left symbolic throughout the compilation process, and is only determined upon execution. This is useful for hybrid quantum-classical algorithms.\n\n> **Note:** Qmod classical types (`CInt`, `CReal`, etc.) remain symbolic through compilation. Parameters declared with plain Python types (`int`, `float`) also work, and can be used in arbitrary Python expressions. But they can't serve as execution parameters, and they might hurt compilation performance. See also [generative descriptions](https://docs.classiq.io/qmod-reference/language-reference/generative-descriptions)."
+   "source": "## 3. Classical Parameters\n\nQmod functions can take **classical** parameters, in addition to quantum parameters. You already used them in Exercise A of Section 2 - the parameters of `prepare_state()`. Classical parameters are declared with Qmod [classical types](https://docs.classiq.io/qmod-reference/language-reference/classical-types) - `CInt`, `CReal`, `CArray`, etc. Classical parameters can be used in Qmod expressions and statements. The size of quantum variables (e.g. `my_qnum.size`) and the length of arrays (e.g. `my_qarr.len`) are also classical expressions in Qmod.\n\nWhen `main` has a classical parameter, its value is left symbolic throughout the compilation process, and is only determined upon execution. This is useful for hybrid quantum-classical algorithms.\n\n> **Note:** Qmod classical types (`CInt`, `CReal`, etc.) remain symbolic through compilation. Parameters declared with plain Python types (`int`, `float`) also work, and can be used in arbitrary Python expressions. But they can't serve as execution parameters, and they might hurt compilation performance. See also [generative descriptions](https://docs.classiq.io/qmod-reference/language-reference/generative-descriptions)."
   },
   {
    "cell_type": "markdown",
@@ -421,7 +421,7 @@
    "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "source": "**Exercise:** Rewrite `rotate` from §3 so that it takes an array of turn-fractions and rotates the *i*th qubit of `qarr` by the *i*th value (you can assume that the arrays are of the same length)."
+   "source": "**Exercise:** Rewrite `rotate` from Section 3 so that it takes an array of turn-fractions and rotates the *i*th qubit of `qarr` by the *i*th value (you can assume that the arrays are of the same length)."
   },
   {
    "cell_type": "code",
@@ -507,7 +507,7 @@
    "id": "32",
    "metadata": {},
    "source": [
-    "> **Expected result:** `x` and `y` are each uniform over 0–3; each row shows `total = x + y` (0–6) and `prod = x * y` (0–9) for that pair of values."
+    "> **Expected result:** `x` and `y` are each uniform over 0-3; each row shows `total = x + y` (0-6) and `prod = x * y` (0-9) for that pair of values."
    ]
   },
   {
@@ -547,7 +547,7 @@
    "id": "35",
    "metadata": {},
    "source": [
-    "> **Expected result:** `acc = 4 + y`, i.e. 4, 5, 6, and 7 — each paired with the `y` that produced it."
+    "> **Expected result:** `acc = 4 + y`, i.e. 4, 5, 6, and 7 - each paired with the `y` that produced it."
    ]
   },
   {
@@ -559,7 +559,7 @@
     "\n",
     "The [`control`](https://docs.classiq.io/qmod-reference/language-reference/statements/control) operator conditionally applies a quantum operation. In its basic form the condition\n",
     "is that all control qubits are $|1\\rangle$, but Qmod generalizes this: the condition can be *any\n",
-    "Boolean expression* over quantum numeric variables — comparisons (`==`, `<`, `>=`, ...) and\n",
+    "Boolean expression* over quantum numeric variables - comparisons (`==`, `<`, `>=`, ...) and\n",
     "logical operators (`&`, `|`). It resembles a classical `if` statement, except the operation is\n",
     "applied *in superposition* over the states that satisfy it.\n",
     "\n",
@@ -611,7 +611,7 @@
    "id": "39",
    "metadata": {},
    "source": [
-    "> **Expected result:** `x` is uniform over `0`–`7`; `target` is `1` only in the row where `x == 5`,\n",
+    "> **Expected result:** `x` is uniform over `0`-`7`; `target` is `1` only in the row where `x == 5`,\n",
     "> and `0` everywhere else."
    ]
   },
@@ -630,7 +630,7 @@
    "id": "41",
    "metadata": {},
    "source": [
-    "### Solution 1 — Quantum Variables and Quantum Types"
+    "### Solution 1 - Quantum Variables and Quantum Types"
    ]
   },
   {
@@ -638,7 +638,7 @@
    "id": "42",
    "metadata": {},
    "source": [
-    "**Exercise A — GHZ on a qubit array**"
+    "**Exercise A - GHZ on a qubit array**"
    ]
   },
   {
@@ -671,7 +671,7 @@
    "id": "44",
    "metadata": {},
    "source": [
-    "**Exercise B — GHZ on a signed integer**"
+    "**Exercise B - GHZ on a signed integer**"
    ]
   },
   {
@@ -697,7 +697,7 @@
    "id": "46",
    "metadata": {},
    "source": [
-    "### Solution 2 — Output Parameters and State-Preparation Functions"
+    "### Solution 2 - Output Parameters and State-Preparation Functions"
    ]
   },
   {
@@ -705,7 +705,7 @@
    "id": "47",
    "metadata": {},
    "source": [
-    "**Exercise A — prepare_state vs. inplace_prepare_state**"
+    "**Exercise A - prepare_state vs. inplace_prepare_state**"
    ]
   },
   {
@@ -738,7 +738,7 @@
    "id": "49",
    "metadata": {},
    "source": [
-    "**Exercise B — fixing the uninitialized variable**"
+    "**Exercise B - fixing the uninitialized variable**"
    ]
   },
   {
@@ -769,7 +769,7 @@
    "id": "51",
    "metadata": {},
    "source": [
-    "### Solution 3 — Classical Parameters"
+    "### Solution 3 - Classical Parameters"
    ]
   },
   {
@@ -777,7 +777,7 @@
    "id": "52",
    "metadata": {},
    "source": [
-    "**Exercise A — a classical expression in a rotation**"
+    "**Exercise A - a classical expression in a rotation**"
    ]
   },
   {
@@ -807,7 +807,7 @@
    "id": "54",
    "metadata": {},
    "source": [
-    "**Exercise B — execution parameters**"
+    "**Exercise B - execution parameters**"
    ]
   },
   {
@@ -833,7 +833,7 @@
    "id": "56",
    "metadata": {},
    "source": [
-    "### Solution 4 — Classical Control Flow"
+    "### Solution 4 - Classical Control Flow"
    ]
   },
   {
@@ -862,7 +862,7 @@
    "id": "58",
    "metadata": {},
    "source": [
-    "### Solution 5 — Quantum Assignment and Arithmetic"
+    "### Solution 5 - Quantum Assignment and Arithmetic"
    ]
   },
   {
@@ -928,7 +928,7 @@
    "id": "63",
    "metadata": {},
    "source": [
-    "### Solution 6 — Control Statements"
+    "### Solution 6 - Control Statements"
    ]
   },
   {

--- a/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
+++ b/tutorials/basic_tutorials/the_classiq_tutorial/Qmod_tutorial_part2.ipynb
@@ -5,9 +5,9 @@
    "id": "0",
    "metadata": {},
    "source": [
-    "# Qmod Tutorial — Part II\n",
+    "# Qmod Tutorial - Part II\n",
     "\n",
-    "Welcome back to the Qmod tutorial! **Part I** introduced the language foundations —\n",
+    "Welcome back to the Qmod tutorial! **Part I** introduced the language foundations -\n",
     "quantum variables and types, output parameters, classical and quantum control flow, and quantum\n",
     "arithmetic. **Part II** (this notebook) builds on those foundations to cover the statements and\n",
     "operators used to express real quantum algorithms.\n",
@@ -23,7 +23,7 @@
     "\n",
     "Each section has a short concept explanation followed by an exercise. Complete the code where\n",
     "marked with `# TODO`, then synthesize and run it. **All solutions are\n",
-    "collected at the end of the notebook** — try each exercise before peeking."
+    "collected at the end of the notebook** - try each exercise before peeking."
    ]
   },
   {
@@ -67,7 +67,7 @@
     "```\n",
     "If $x$ is a `QNum` in the range $[0, 1, 2, 3]$ it rotates $|1\\rangle$ by $\\pi/4$, $|2\\rangle$ by $4\\pi/4$ (i.e., half turn), and $|3\\rangle$ by $9\\pi/4$ (coming back to $\\pi/4$).\n",
     "\n",
-    "> **Note**: An optional second argument multiplies the expression by a classical coefficient (Part I, §3) — typically an execution parameter, as in a QAOA cost layer.\n",
+    "> **Note**: An optional second argument multiplies the expression by a classical coefficient (Part I, Section 3) - typically an execution parameter, as in a QAOA cost layer.\n",
     "\n",
     "When the phase expression contains no quantum variables, the same phase is applied across all states. Still, this can be restricted to certain states by an enclosing `control` statement.\n",
     "\n",
@@ -78,7 +78,7 @@
     "\n",
     "Phase statements are the workhorse behind **phase oracles** (as in Grover's algorithm) and **cost functions** (as in QAOA).\n",
     "\n",
-    "> **Note**: Phases are invisible to ordinary sampling — they don't change measurement probabilities. To \"see\" them, use the top-level `calculate_state_vector(qprog)`, which returns the amplitude (including phase) of each state."
+    "> **Note**: Phases are invisible to ordinary sampling - they don't change measurement probabilities. To \"see\" them, use the top-level `calculate_state_vector(qprog)`, which returns the amplitude (including phase) of each state."
    ]
   },
   {
@@ -86,7 +86,7 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "**Exercise A:** Put two 2-qubit numbers `x` and `y` into uniform superposition, then encode their product `x * y` into the phase, scaled by a coefficient of $2\\pi / 2^N = \\pi/8$ (with $N = 4$ the total number of qubits). This divides the full turn into $2^N = 16$ equal steps — one per unit of the product — so distinct product values land on distinct phases. Use `calculate_state_vector` to inspect the resulting phases."
+    "**Exercise A:** Put two 2-qubit numbers `x` and `y` into uniform superposition, then encode their product `x * y` into the phase, scaled by a coefficient of $2\\pi / 2^N = \\pi/8$ (with $N = 4$ the total number of qubits). This divides the full turn into $2^N = 16$ equal steps - one per unit of the product - so distinct product values land on distinct phases. Use `calculate_state_vector` to inspect the resulting phases."
    ]
   },
   {
@@ -118,7 +118,7 @@
    "id": "6",
    "metadata": {},
    "source": [
-    "> **Expected result:** every basis state has probability 1/16, but the `phase` column shows a rotation of $(x \\cdot y)\\,\\pi/8$ for each state — e.g. `x=2, y=1` gives $0.25\\pi$, and `x=3, y=3` gives $9\\pi/8$ (shown as $-0.88\\pi$, i.e. modulo $2\\pi$)."
+    "> **Expected result:** every basis state has probability 1/16, but the `phase` column shows a rotation of $(x \\cdot y)\\,\\pi/8$ for each state - e.g. `x=2, y=1` gives $0.25\\pi$, and `x=3, y=3` gives $9\\pi/8$ (shown as $-0.88\\pi$, i.e. modulo $2\\pi$)."
    ]
   },
   {
@@ -126,7 +126,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "**Exercise B:** A **phase oracle** flips the phase (a rotation by $\\pi$) of the basis states that satisfy some condition — the marking step at the heart of Grover's algorithm. Using two 2-qubit numbers `a` and `b` in uniform superposition, complete `mark_solutions` to flip the phase of every state satisfying $3a + b = 9$ (similar to the exercise in Part I, §6). Then inspect the statevector to confirm which states were marked."
+    "**Exercise B:** A **phase oracle** flips the phase (a rotation by $\\pi$) of the basis states that satisfy some condition - the marking step at the heart of Grover's algorithm. Using two 2-qubit numbers `a` and `b` in uniform superposition, complete `mark_solutions` to flip the phase of every state satisfying $3a + b = 9$ (similar to the exercise in Part I, Section 6). Then inspect the statevector to confirm which states were marked."
    ]
   },
   {
@@ -164,7 +164,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "> **Expected result:** all 16 basis states keep probability 1/16, but exactly two of them — the assignments satisfying $3a+b=9$: `(a, b) = (3, 0)` and `(2, 3)` — show a phase of `π`; every other state shows `0`."
+    "> **Expected result:** all 16 basis states keep probability 1/16, but exactly two of them - the assignments satisfying $3a+b=9$: `(a, b) = (3, 0)` and `(2, 3)` - show a phase of $\\pi$; every other state shows `0`."
    ]
   },
   {
@@ -174,7 +174,7 @@
    "source": [
     "## 8. Local Variables, Permutations, and Auto-Uncomputation\n",
     "\n",
-    "Inside a quantum function you can declare a **local** quantum variable and use it to hold intermediate results. This is very handy in breaking computations into smaller steps. When a local goes out of scope, Qmod **uncomputes** it automatically — reversing the operations that set it, so its qubits return to $|0\\rangle$ and can be reused.\n",
+    "Inside a quantum function you can declare a **local** quantum variable and use it to hold intermediate results. This is very handy in breaking computations into smaller steps. When a local goes out of scope, Qmod **uncomputes** it automatically - reversing the operations that set it, so its qubits return to $|0\\rangle$ and can be reused.\n",
     "\n",
     "For example, the following declares a numeric local variable `v` and assigns it the computational-basis value 3.\n",
     "```python\n",
@@ -182,7 +182,7 @@
     "v |= 3\n",
     "```\n",
     "\n",
-    "Uncomputation can work as long as the local variable was modified by **permutations** — operations that map basis states to basis states without creating superposition, such as gate-level functions `X` and `CX`, as well as higher level arithmetic (Part I, §5). If a local can't be uncomputed automatically the compiler will issue an error. You can discard the variable explicitly with `drop` or manually uncompute it and call `free`. See [uncomputation](https://docs.classiq.io/qmod-reference/language-reference/uncomputation) for the full rules."
+    "Uncomputation can work as long as the local variable was modified by **permutations** - operations that map basis states to basis states without creating superposition, such as gate-level functions `X` and `CX`, as well as higher level arithmetic (Part I, Section 5). If a local can't be uncomputed automatically the compiler will issue an error. You can discard the variable explicitly with `drop` or manually uncompute it and call `free`. See [uncomputation](https://docs.classiq.io/qmod-reference/language-reference/uncomputation) for the full rules."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "id": "11",
    "metadata": {},
    "source": [
-    "**Exercise:** Put a 2-qubit number `x` into uniform superposition. Use a *local* variable `tmp` to store $2x+1$, and depending on `tmp > 3`, flip `res`. `tmp` is a scratch variable — it is uncomputed automatically at the end of the function, so it never appears in the output."
+    "**Exercise:** Put a 2-qubit number `x` into uniform superposition. Use a *local* variable `tmp` to store $2x+1$, and depending on `tmp > 3`, flip `res`. `tmp` is a scratch variable - it is uncomputed automatically at the end of the function, so it never appears in the output."
    ]
   },
   {
@@ -223,7 +223,7 @@
    "id": "13",
    "metadata": {},
    "source": [
-    "> **Expected result:** `x` is uniform over 0–3, and `res` is `1` exactly when `tmp = 2x + 1 > 3` — that is, when `x > 1` (`x` is 2 or 3). The scratch variable `tmp` was uncomputed automatically, so the output contains only `x` and `res`."
+    "> **Expected result:** `x` is uniform over 0-3, and `res` is `1` exactly when `tmp = 2x + 1 > 3` - that is, when `x > 1` (`x` is 2 or 3). The scratch variable `tmp` was uncomputed automatically, so the output contains only `x` and `res`."
    ]
   },
   {
@@ -233,14 +233,14 @@
    "source": [
     "## 9. Within-Apply\n",
     "\n",
-    "Many quantum routines are based on the conjugation pattern: transform the state with some operation $U$, perform an operation $V$ in that transformed basis, then transform back, with the net effect – $U^\\dagger V U$. The [within-apply](https://docs.classiq.io/qmod-reference/language-reference/statements/within-apply) statement captures this directly. When this pattern is subject to quantum control, only the `apply` block (the $V$ operation) actually needs to be controlled.\n",
+    "Many quantum routines are based on the conjugation pattern: transform the state with some operation $U$, perform an operation $V$ in that transformed basis, then transform back, with the net effect - $U^\\dagger V U$. The [within-apply](https://docs.classiq.io/qmod-reference/language-reference/statements/within-apply) statement captures this directly. When this pattern is subject to quantum control, only the `apply` block (the $V$ operation) actually needs to be controlled.\n",
     "\n",
     "For example, the following applies `Z` to a qubit `q` in the Hadamard basis (which is equivalent to applying `X` to `q`):\n",
     "```python\n",
     "within_apply(lambda: H(q), lambda: Z(q))\n",
     "```\n",
     "\n",
-    "> **Note**: Initializing a variable in the `within` block implies that its inverse uncomputes and frees it. Hence, such a variable is subject to the same rules as local variables we discussed in §8."
+    "> **Note**: Initializing a variable in the `within` block implies that its inverse uncomputes and frees it. Hence, such a variable is subject to the same rules as local variables we discussed in Section 8."
    ]
   },
   {
@@ -280,7 +280,7 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "> **Expected result:** `x` is uniform over 0–7, and each row's `y` equals `x + 2` (so `y` ranges 2–9) — the in-place addition carried out entirely through phase rotations in the Fourier basis."
+    "> **Expected result:** `x` is uniform over 0-7, and each row's `y` equals `x + 2` (so `y` ranges 2-9) - the in-place addition carried out entirely through phase rotations in the Fourier basis."
    ]
   },
   {
@@ -288,7 +288,7 @@
    "id": "18",
    "metadata": {},
    "source": [
-    "**Exercise B:** Now perform the *same* addition, but only when a control qubit `ctrl` is $|1\\rangle$ — put the whole `within_apply` under a `control` on `ctrl`. Then run `show(qprog)` and inspect the quantum program: notice that the `qft` and its inverse are **not** controlled — only the `apply` (phase) block is."
+    "**Exercise B:** Now perform the *same* addition, but only when a control qubit `ctrl` is $|1\\rangle$ - put the whole `within_apply` under a `control` on `ctrl`. Then run `show(qprog)` and inspect the quantum program: notice that the `qft` and its inverse are **not** controlled - only the `apply` (phase) block is."
    ]
   },
   {
@@ -332,7 +332,7 @@
    "source": [
     "## 10. Hamiltonians, Pauli Operators, and Exponentiation\n",
     "\n",
-    "The four **Pauli matrices** `I`, `X`, `Y`, `Z` are the building blocks of qubit operators. A **Hamiltonian** — a system's energy operator — can be represented as a weighted sum of Pauli matrix products. In Qmod this is called **Pauli operator**, and you build it from the `Pauli` enum, where `Pauli.X(0)` is `X` on qubit 0; multiply to form a product (unmentioned qubits are implicitly `I`), and add to sum terms.\n",
+    "The four **Pauli matrices** `I`, `X`, `Y`, `Z` are the building blocks of qubit operators. A **Hamiltonian** - a system's energy operator - can be represented as a weighted sum of Pauli matrix products. In Qmod this is called **Pauli operator**, and you build it from the `Pauli` enum, where `Pauli.X(0)` is `X` on qubit 0; multiply to form a product (unmentioned qubits are implicitly `I`), and add to sum terms.\n",
     "\n",
     "Here is an example Hamiltonian:\n",
     "\n",
@@ -342,7 +342,7 @@
     "\n",
     "A Hamiltonian drives time evolution through $U(t) = e^{-iHt}$. Exact gate decomposition of this operator can be exponentially large, so the **Suzuki-Trotter** decomposition approximates it as `r` repeated short steps over the individual terms. The built-in function [`suzuki_trotter`](https://docs.classiq.io/qmod-reference/library-reference/core-library-functions/hamiltonian_evolution/suzuki_trotter/suzuki_trotter) applies it, given the Hamiltonian, the evolution time, the order, and the repetitions `r`.\n",
     "\n",
-    "A Pauli operator can also serve as an **observable** — a quantity whose expectation value $\\langle\\psi|O|\\psi\\rangle$ we measure. Where `sample` returns the distribution over basis states, the SDK function `observe` returns the expectation value of a given observable."
+    "A Pauli operator can also serve as an **observable** - a quantity whose expectation value $\\langle\\psi|O|\\psi\\rangle$ we measure. Where `sample` returns the distribution over basis states, the SDK function `observe` returns the expectation value of a given observable."
    ]
   },
   {
@@ -411,7 +411,7 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "> **Expected result:** `observe` returns `2.0` — each qubit is in $|+\\rangle$, the $+1$ eigenstate of `X`, so $\\langle X_0\\rangle = \\langle X_1\\rangle = 1$."
+    "> **Expected result:** `observe` returns `2.0` - each qubit is in $|+\\rangle$, the $+1$ eigenstate of `X`, so $\\langle X_0\\rangle = \\langle X_1\\rangle = 1$."
    ]
   },
   {
@@ -432,7 +432,7 @@
     "\n",
     "Higher-order functions are very useful for capturing recurring patterns in quantum algorithms. Examples are the Quantum Phase Estimation (QPE) and the Grover double-reflection operator.\n",
     "\n",
-    "> **Note:** Passing a lambda to a higher-order function works just like passing one to a built-in statement — e.g. `repeat(qarr.len, lambda i: H(qarr[i]))`, where `i` is the lambda's CInt parameter (Part I, §4).\n",
+    "> **Note:** Passing a lambda to a higher-order function works just like passing one to a built-in statement - e.g. `repeat(qarr.len, lambda i: H(qarr[i]))`, where `i` is the lambda's CInt parameter (Part I, Section 4).\n",
     "\n",
     "See more under [operators](https://docs.classiq.io/qmod-reference/language-reference/operators)."
    ]
@@ -442,7 +442,7 @@
    "id": "28",
    "metadata": {},
    "source": [
-    "**Exercise A:** Define `my_apply_to_all` — a higher-order function that applies a single-qubit operation `op` to every qubit of `qarr`. Then use it to apply `H` to all three qubits, producing a uniform superposition."
+    "**Exercise A:** Define `my_apply_to_all` - a higher-order function that applies a single-qubit operation `op` to every qubit of `qarr`. Then use it to apply `H` to all three qubits, producing a uniform superposition."
    ]
   },
   {
@@ -476,7 +476,7 @@
    "id": "30",
    "metadata": {},
    "source": [
-    "> **Expected result:** all eight bit strings appear with roughly equal ~1/8 probability — `H` was applied to every qubit."
+    "> **Expected result:** all eight bit strings appear with roughly equal ~1/8 probability - `H` was applied to every qubit."
    ]
   },
   {
@@ -484,7 +484,7 @@
    "id": "31",
    "metadata": {},
    "source": [
-    "**Exercise B:** [`qpe`](https://docs.classiq.io/qmod-reference/library-reference/open-library-functions/qpe/qpe) (quantum phase estimation) is a built-in higher-order function: given a unitary `U` as its operand, it estimates the phase $\\theta$ of an eigenstate, where $U|\\psi\\rangle = e^{2\\pi i\\theta}|\\psi\\rangle$, and writes it into a `QNum`. Here `|11⟩` is an eigenstate of `CRZ(pi, state[0], state[1])` with $\\theta = 0.25$. Complete the `qpe` call to estimate it."
+    "**Exercise B:** [`qpe`](https://docs.classiq.io/qmod-reference/library-reference/open-library-functions/qpe/qpe) (quantum phase estimation) is a built-in higher-order function: given a unitary `U` as its operand, it estimates the phase $\\theta$ of an eigenstate, where $U|\\psi\\rangle = e^{2\\pi i\\theta}|\\psi\\rangle$, and writes it into a `QNum`. Here $|11\\rangle$ is an eigenstate of `CRZ(pi, state[0], state[1])` with $\\theta = 0.25$. Complete the `qpe` call to estimate it."
    ]
   },
   {
@@ -518,7 +518,7 @@
    "id": "33",
    "metadata": {},
    "source": [
-    "> **Expected result:** `theta` comes out `0.25` with near-certainty — the phase of `CRZ(pi)` on its eigenstate `|11⟩`."
+    "> **Expected result:** `theta` comes out `0.25` with near-certainty - the phase of `CRZ(pi)` on its eigenstate $|11\\rangle$."
    ]
   },
   {
@@ -528,7 +528,7 @@
    "source": [
     "## 12. Execution Parameters and Hybrid Execution\n",
     "\n",
-    "Many quantum algorithms are hybrid: a classical program drives a quantum one, running it repeatedly at different parameter values and processing the results. This builds on the **execution parameters** from Part I, §3 — classical `main` parameters (`CReal`, `CArray[CReal]`, ...) that stay symbolic through synthesis. You synthesize once and execute the same quantum program multiple times. The classical logic can be a variational optimizer minimizing a cost (VQE, QAOA), an iterative scheme adapting parameters from measured outcomes (IQAE), or a sweep over values fixed by classical processing (such as Shor).\n",
+    "Many quantum algorithms are hybrid: a classical program drives a quantum one, running it repeatedly at different parameter values and processing the results. This builds on the **execution parameters** from Part I, Section 3 - classical `main` parameters (`CReal`, `CArray[CReal]`, ...) that stay symbolic through synthesis. You synthesize once and execute the same quantum program multiple times. The classical logic can be a variational optimizer minimizing a cost (VQE, QAOA), an iterative scheme adapting parameters from measured outcomes (IQAE), or a sweep over values fixed by classical processing (such as Shor).\n",
     "\n",
     "Values are supplied at execution through the `parameters` argument of `sample` or `observe`, a dict mapping each parameter name to its value.\n",
     "\n",
@@ -538,7 +538,7 @@
     "sample(qprog, parameters={\"params\": [0.2, 1.0]})\n",
     "```\n",
     "\n",
-    "Use `sample` for the measured distribution, or `observe` for an expectation value $\\langle H \\rangle$ of a Hamiltonian (§10) — the cost a variational algorithm minimizes. See [execution](https://docs.classiq.io/user-guide/execution/index) for all options.\n",
+    "Use `sample` for the measured distribution, or `observe` for an expectation value $\\langle H \\rangle$ of a Hamiltonian (Section 10) - the cost a variational algorithm minimizes. See [execution](https://docs.classiq.io/user-guide/execution/index) for all options.\n",
     "\n",
     "> **Note:** Execution parameters are ordinary numbers, so use Python floats (e.g. `math.pi`), not the symbolic `pi` used inside function bodies."
    ]
@@ -548,7 +548,7 @@
    "id": "35",
    "metadata": {},
    "source": [
-    "**Exercise A:** The parametric program below rotates two qubits by `params[0]` and `params[1]`, then entangles them (one layer of a typical ansatz). Synthesize it *once*, then — reusing that same `qprog` — `sample` it at two different settings, `[0.2, 1.0]` and `[1.5, 0.5]`, and compare the distributions."
+    "**Exercise A:** The parametric program below rotates two qubits by `params[0]` and `params[1]`, then entangles them (one layer of a typical ansatz). Synthesize it *once*, then - reusing that same `qprog` - `sample` it at two different settings, `[0.2, 1.0]` and `[1.5, 0.5]`, and compare the distributions."
    ]
   },
   {
@@ -606,7 +606,7 @@
    "id": "40",
    "metadata": {},
    "source": [
-    "> **Expected result:** `observe` returns a single number, $\\langle H\\rangle \\approx 0.86$ — the expectation value on the state prepared at those parameters."
+    "> **Expected result:** `observe` returns a single number, $\\langle H\\rangle \\approx 0.86$ - the expectation value on the state prepared at those parameters."
    ]
   },
   {
@@ -624,7 +624,7 @@
    "id": "42",
    "metadata": {},
    "source": [
-    "### Solution 7 — Phase Statements"
+    "### Solution 7 - Phase Statements"
    ]
   },
   {
@@ -632,7 +632,7 @@
    "id": "43",
    "metadata": {},
    "source": [
-    "**Exercise A — encoding a product into the phase**"
+    "**Exercise A - encoding a product into the phase**"
    ]
   },
   {
@@ -661,7 +661,7 @@
    "id": "45",
    "metadata": {},
    "source": [
-    "**Exercise B — a Grover-style phase oracle**"
+    "**Exercise B - a Grover-style phase oracle**"
    ]
   },
   {
@@ -695,7 +695,7 @@
    "id": "47",
    "metadata": {},
    "source": [
-    "### Solution 8 — Local Variables, Permutations, and Auto-Uncomputation"
+    "### Solution 8 - Local Variables, Permutations, and Auto-Uncomputation"
    ]
   },
   {
@@ -726,7 +726,7 @@
    "id": "49",
    "metadata": {},
    "source": [
-    "### Solution 9 — Within-Apply"
+    "### Solution 9 - Within-Apply"
    ]
   },
   {
@@ -734,7 +734,7 @@
    "id": "50",
    "metadata": {},
    "source": [
-    "**Exercise A — within-apply addition**"
+    "**Exercise A - within-apply addition**"
    ]
   },
   {
@@ -765,7 +765,7 @@
    "id": "52",
    "metadata": {},
    "source": [
-    "**Exercise B — the same addition under control**"
+    "**Exercise B - the same addition under control**"
    ]
   },
   {
@@ -801,7 +801,7 @@
    "id": "54",
    "metadata": {},
    "source": [
-    "### Solution 10 — Hamiltonians, Pauli Operators, and Exponentiation"
+    "### Solution 10 - Hamiltonians, Pauli Operators, and Exponentiation"
    ]
   },
   {
@@ -809,7 +809,7 @@
    "id": "55",
    "metadata": {},
    "source": [
-    "**Exercise A — Suzuki-Trotter evolution**"
+    "**Exercise A - Suzuki-Trotter evolution**"
    ]
   },
   {
@@ -842,7 +842,7 @@
    "id": "57",
    "metadata": {},
    "source": [
-    "**Exercise B — measuring an observable with `observe`**"
+    "**Exercise B - measuring an observable with `observe`**"
    ]
   },
   {
@@ -868,7 +868,7 @@
    "id": "59",
    "metadata": {},
    "source": [
-    "### Solution 11 — Higher-Order Functions"
+    "### Solution 11 - Higher-Order Functions"
    ]
   },
   {
@@ -876,7 +876,7 @@
    "id": "60",
    "metadata": {},
    "source": [
-    "**Exercise A — a user-defined higher-order function**"
+    "**Exercise A - a user-defined higher-order function**"
    ]
   },
   {
@@ -907,7 +907,7 @@
    "id": "62",
    "metadata": {},
    "source": [
-    "**Exercise B — using the built-in `qpe`**"
+    "**Exercise B - using the built-in `qpe`**"
    ]
   },
   {
@@ -937,7 +937,7 @@
    "id": "64",
    "metadata": {},
    "source": [
-    "### Solution 12 — Execution Parameters and Hybrid Execution"
+    "### Solution 12 - Execution Parameters and Hybrid Execution"
    ]
   },
   {
@@ -945,7 +945,7 @@
    "id": "65",
    "metadata": {},
    "source": [
-    "**Exercise A — sampling a parametric circuit**"
+    "**Exercise A - sampling a parametric circuit**"
    ]
   },
   {
@@ -974,7 +974,7 @@
    "id": "67",
    "metadata": {},
    "source": [
-    "**Exercise B — an expectation value with `observe`**"
+    "**Exercise B - an expectation value with `observe`**"
    ]
   },
   {


### PR DESCRIPTION
## What

Replaces stray unicode typography in the two Qmod tutorial notebooks with ASCII/LaTeX, bringing the `unicode` convention point to **100% (219/219)**.

Both notebooks were the only remaining offenders. All changes are in **markdown cells** (prose) only:

| From | To | Where |
|---|---|---|
| `—` em dash, `–` en dash | `-` | heading separators (`Solution 1 — …`), numeric ranges (`0–3`) |
| `→` rightwards arrow | `->` | `synthesis → visualization → execution` |
| `§N` section sign | `Section N` | cross-refs (`§2`, `§3`, `§10`) |
| `` `|11⟩` `` | `$|11\rangle$` | ket in code span |
| `` `π` `` | `$\pi$` | pi in code span |

## Verification

- `unicode`: 219/219 (100%)
- `title_case`: still 219/219 (the em-dash→hyphen change in headings preserves title case)
- nbformat valid; no cell-source corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)