### PR TITLE
ci: run notebook execution only when code cells change

### DIFF
--- a/.github/workflows/Test-CI-main.yml
+++ b/.github/workflows/Test-CI-main.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 20 # enough history for `git show BASE_SHA:notebook` (PRs are ~1-4 commits)
           persist-credentials: false
           allow-unsafe-pr-checkout: true
 
@@ -146,6 +147,49 @@ jobs:
           files: |
             **/notebooks/**/test_*.py
 
+      # Narrow the changed-notebook list down to notebooks whose *code* cells changed,
+      # so a markdown-only edit no longer triggers the (expensive) notebook execution.
+      # The cheap link/quick tests above are unaffected - they run on all files.
+      - name: Filter to notebooks whose code cells changed
+        id: code-changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          ALL_CHANGED: ${{ steps.changed-files-ipynb.outputs.all_changed_files }}
+          # safety switch: set to "false" to fall back to the old "any change" behavior
+          SKIP_MARKDOWN_ONLY: "true"
+        run: |
+          set -euo pipefail
+
+          # Just the code-cell sources, in order (markdown, outputs, metadata ignored).
+          extract_code_cells () {
+              jq -S '
+                  [ .cells[]
+                    | select(.cell_type == "code")
+                    | .source
+                    | if type == "array" then join("") else . end
+                  ]
+              '
+          }
+
+          kept=()
+          for notebook in $ALL_CHANGED; do
+              if [ "$SKIP_MARKDOWN_ONLY" != "true" ]; then
+                  # feature disabled -> keep every changed notebook
+                  kept+=("$notebook")
+              else
+                  new_code=$(extract_code_cells < "$notebook")
+                  if old_code=$(git show "$BASE_SHA:$notebook" 2>/dev/null | extract_code_cells 2>/dev/null); then
+                      if [ "$old_code" != "$new_code" ]; then
+                          kept+=("$notebook")   # code differs -> keep
+                      fi
+                  else
+                      kept+=("$notebook")       # new notebook -> keep
+                  fi
+              fi
+          done
+
+          echo "list=${kept[*]}" >> "$GITHUB_OUTPUT"
+
       # Run Tests
       - name: Run Notebooks (quick tests)
         run: python -m pytest -c tests/config_quick_tests.ini --rootdir=.
@@ -164,9 +208,9 @@ jobs:
         env:
           # to disable a warning in Jupyter notebooks
           JUPYTER_PLATFORM_DIRS: "1"
-          # Passing which notebooks changed
+          # Passing which notebooks changed (code-cell changes only; markdown-only edits are filtered out)
           SHOULD_TEST_ALL_FILES: "${{ env.SHOULD_TEST_ALL_FILES }}"
-          LIST_OF_IPYNB_CHANGED: "${{ steps.changed-files-ipynb.outputs.all_changed_files }}"
+          LIST_OF_IPYNB_CHANGED: "${{ steps.code-changed.outputs.list }}"
           LIST_OF_IPYNB_TESTS_CHANGED: "${{ steps.changed-files-tests.outputs.all_changed_files }}"
           # Altering test behavior
           LIMIT_TEST_LINKS_TO_FILES_ONLY: "false"


### PR DESCRIPTION
## What

Only run the (expensive) **notebook-execution** step for notebooks whose **code cells** actually changed. A markdown-only edit no longer triggers notebook execution.

## How

A new `code-changed` step narrows the changed-`.ipynb` list down to notebooks whose code-cell sources differ from the base revision (`jq` extracts code-cell `.source`; markdown, outputs and metadata are ignored). Its output feeds **only** the execute step's `LIST_OF_IPYNB_CHANGED`.

- The cheap **link/quick** tests are unaffected — they still run on all files, so markdown-only link edits stay covered.
- The **test-file** trigger (`LIST_OF_IPYNB_TESTS_CHANGED`) is unchanged.
- `SKIP_MARKDOWN_ONLY` is a safety switch — set it to `"false"` to fall back to the old "any change" behavior.
- Added `fetch-depth: 20` to the fork checkout so the base revision is available for the code-cell diff (PRs are typically 1–4 commits).

## Verification

Ran the exact filter logic (`jq` + `git show BASE_SHA:notebook`) locally against three notebooks:

| Notebook | Change | Result |
|---|---|---|
| `entanglement` | markdown-only | skip |
| `hadamard_test` | code-only | run |
| `bernstein_vazirani` | both | run |

## Note

The trigger is `pull_request_target`, which runs the workflow from `main` — so this only takes effect **after merge**. This PR itself still runs under the old workflow. First real confirmation will be a dummy markdown-only PR opened after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
