### PR TITLE
test(ci): markdown-only change — execution should be skipped [do not merge]

### DIFF
--- a/tutorials/basic_tutorials/entanglement/entanglement.ipynb
+++ b/tutorials/basic_tutorials/entanglement/entanglement.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# Quantum Entanglement with Classiq\n",
     "\n",
-    "Entanglement is an important aspect to study quantum algorithms. In this tutorial, we show how to create a bell pair state $|\\Phi^{+}\\rangle$ of 2 qubits, using the Hadamard and the Controlled-NOT transformation."
+    "Entanglement is an important aspect to study quantum algorithms. In this tutorial, we show how to create a bell pair state $|\\Phi^{+}\\rangle$ of 2 qubits, using the Hadamard and the Controlled-NOT transformation.\n",
+    "\n",
+    "<!-- CI test: markdown-only change; notebook execution should be skipped -->"
    ]
   },
   {


### PR DESCRIPTION
**⚠️ Do not merge — CI test PR.**

Touches **only a markdown cell** of `entanglement.ipynb` (an invisible HTML comment). No code cell changes.

### What to look for in `Test Library CI (main)`

- **`Filter to notebooks whose code cells changed`** step → outputs an **empty** `list=` (entanglement's code cells are identical to base).
- **`Run Notebooks (executing notebooks and testing content)`** → selects **0 notebooks**, so no execution against the platform. ✅ this is the win.
- **`Run Notebooks (quick tests)`** / link checks → still run on all files (unaffected).

If execution is skipped here, the code-cell filter works end-to-end through the real `pull_request_target` path.

Close without merging once confirmed.
